### PR TITLE
Fixed bug where AllocationUnitSize was not used

### DIFF
--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -197,7 +197,7 @@ function Test-TargetResource
         }
     }
     $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select BlockSize
-    if($BlockSize)
+    if($BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {
         if($AllocationUnitSize -ne $BlockSize.BlockSize)
         {


### PR DESCRIPTION
If AllocationUnitSize is left out then it defaults to 0 which then caused the Test method to fail.