### PR TITLE
Bug fix related to BlockSize

### DIFF
--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -197,7 +197,7 @@ function Test-TargetResource
         }
     }
     $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select BlockSize
-    if($BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
+    if($BlockSize.BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {
         if($AllocationUnitSize -ne $BlockSize.BlockSize)
         {


### PR DESCRIPTION
Cannot compare "@{BlockSize=4096}" to "0" because the objects are not the same type or the object "@{BlockSize=4096}" does not implement "IComparable".