### PR TITLE
Fix bug where drive letter was not correctly assigned to.

### DIFF
--- a/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -91,7 +91,7 @@ function Set-TargetResource
         }
 
         #Verify drive letter        
-        $CimVolume = Get-CimInstance -ClassName Win32_Volume | where {$_.DeviceId -eq $Image.ObjectId}
+        $CimVolume = Get-CimInstance -ClassName Win32_Volume | where {$_.Name -eq "$($Image.DriveLetter):\"}
         If($CimVolume.DriveLetter -ne $DriveLetter)
         {
             Write-Verbose "Drive letter does not match expected value. Expected DriveLetter $DriveLetter Actual DriverLetter $($CimVolume.DriveLetter)"

--- a/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -152,7 +152,7 @@ function Test-TargetResource
         }
 
         #Verify drive letter        
-        $CimVolume = Get-CimInstance -ClassName Win32_Volume | where {$_.DeviceId -eq $Image.ObjectId}
+        $CimVolume = Get-CimInstance -ClassName Win32_Volume | where {$_.Name -eq "$($Image.DriveLetter):\"}
         If($CimVolume.DriveLetter -ne $DriveLetter)
         {
             Write-Verbose "Drive letter does not match expected value. Expected DriveLetter $DriveLetter Actual DriverLetter $($CimVolume.DriveLetter)"


### PR DESCRIPTION
I can't use the `xMountImage` resource to assign drive letters. It's because the code is not finding the `CimVolume` because the image ID is no longer the same format. I've changed it to use a drive letter to find the `CimVolume` instead, which I think is simpler. 

My guess is that on Windows 10, the image object ID format changed from
this format:
?\Volume{5c711983-ceb6-11e5-9807-b00594f915af}\"

to the following format:
{1}\\DESKTOP-0D8R59D\root/Microsoft/Windows/Storage/Providers_v2\WSP_Volume.ObjectId="{4c372dcb-ce72-11e5-9804-806e6f6e6963}:VO:\\?\Volume{5c711983-ceb6-11e5-9807-b00594f915af}\"