### PR TITLE
Fixed bug: Cannot compare "@{BlockSize=4096}" to "0"

### DIFF
--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -24,9 +24,10 @@ function Get-TargetResource
 
     $FSLabel = Get-Volume -DriveLetter $DriveLetter -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FileSystemLabel
 
-    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select BlockSize
+    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue | select -ExpandProperty BlockSize
+    
     if($BlockSize){
-        $AllocationUnitSize = $BlockSize.BlockSize
+        $AllocationUnitSize = $BlockSize
     }
 
     $returnValue = @{
@@ -196,10 +197,12 @@ function Test-TargetResource
             return $false
         }
     }
-    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select BlockSize
+
+    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select -ExpandProperty BlockSize
+    
     if($BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {
-        if($AllocationUnitSize -ne $BlockSize.BlockSize)
+        if($AllocationUnitSize -ne $BlockSize)
         {
             # Just write a warning, we will not try to reformat a drive due to invalid allocation unit sizes
             Write-Verbose "Drive $DriveLetter allocation unit size does not match expected value. Current: $($BlockSize.BlockSize/1kb)kb Expected: $($AllocationUnitSize/1kb)kb"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ We reserve resource and module names without prefixes ("x" or "c") for future us
 
 ### Unreleased
 
+### 2.5.0.0
+
+* Fixed bug related to BlockSize comparison with 0
+
 ### 2.4.0.0
 
 * Fixed bug where AllocationUnitSize was not used


### PR DESCRIPTION
Fixed bug where DSC configuration fails on a machine where the disk is already initialised. The bug was due to not expanding the property BlockSize after the WMI query.