### PR TITLE
Fix Exception Handling in xDisk #29

### DIFF
--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -146,7 +146,8 @@ function Set-TargetResource
     }    
     catch
     {
-        Throw "Disk Set-TargetResource failed with the following error: '$($Error[0])'"
+        $message = $_.Exception.Message
+        Throw "Disk Set-TargetResource failed with the following error: '$($message)'"
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ We reserve resource and module names without prefixes ("x" or "c") for future us
 * added test for existing file system to allow simple drive letter assignment in MSFT_xDisk.psm1 
 * modified Test verbose message to correctly reflect blocksize value in MSFT_xDisk.psm1 line 217
 * added unit test for new volume with out existing partition for MSFT_xDisk.psm1 
+* Fixed error propagation
 
 ### 2.4.0.0
 


### PR DESCRIPTION
The xDisk DSC Resource does not handle exceptions correctly. It
relied on `$($Error[0])` to display the error, but does not work
as the built in variable has not been populated yet with the exception.
We fixed this by capturing the Message property of the caught Exception
object and displaying that.

Fixes Issue #29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/30)
<!-- Reviewable:end -->
