### PR TITLE
MSFT_xDisk.psm1: Replaced Get-WmiObject with Get-CimInstance

### DIFF
--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -24,7 +24,7 @@ function Get-TargetResource
 
     $FSLabel = Get-Volume -DriveLetter $DriveLetter -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FileSystemLabel
 
-    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue | select -ExpandProperty BlockSize
+    $BlockSize = Get-CimInstance -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue | select -ExpandProperty BlockSize
     
     if($BlockSize){
         $AllocationUnitSize = $BlockSize
@@ -211,7 +211,7 @@ function Test-TargetResource
         }
     }
 
-    $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select -ExpandProperty BlockSize
+    $BlockSize = Get-CimInstance -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select -ExpandProperty BlockSize
     
     if($BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {

--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -28,6 +28,10 @@ function Get-TargetResource
     
     if($BlockSize){
         $AllocationUnitSize = $BlockSize
+    } else {
+        # If Get-CimInstance did not return a value, try again with Get-WmiObject
+        $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue | select -ExpandProperty BlockSize
+        $AllocationUnitSize = $BlockSize
     }
 
     $returnValue = @{
@@ -212,7 +216,11 @@ function Test-TargetResource
     }
 
     $BlockSize = Get-CimInstance -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select -ExpandProperty BlockSize
-    
+    if (-not($BlockSize)){
+        # If Get-CimInstance did not return a value, try again with Get-WmiObject
+        $BlockSize = Get-WmiObject -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" -ErrorAction SilentlyContinue  | select -ExpandProperty BlockSize
+    }
+
     if($BlockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {
         if($AllocationUnitSize -ne $BlockSize)

--- a/tests/unit/MSFT_xDisk.tests.ps1
+++ b/tests/unit/MSFT_xDisk.tests.ps1
@@ -71,7 +71,8 @@ try
         #region Function Get-TargetResource
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
             # verifiable (should be called) mocks 
-            Mock Get-WmiObject -mockwith {return $global:mockedWmi} -verifiable
+            Mock Get-WmiObject -mockwith {return $global:mockedWmi}
+            Mock Get-CimInstance -mockwith {return $global:mockedWmi} 
             Mock Get-Disk -mockwith {return $global:mockedDisk0} -verifiable
             Mock Get-Partition -mockwith {return $Global:mockedPartition} -verifiable
             Mock Get-Volume -mockwith {return $global:mockedVolume} -verifiable
@@ -109,7 +110,8 @@ try
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
             context 'Test matching AllocationUnitSize' {
                 # verifiable (should be called) mocks 
-                Mock Get-WmiObject -mockwith {return $global:mockedWmi} -verifiable
+                Mock Get-WmiObject -mockwith {return $global:mockedWmi} 
+                Mock Get-CimInstance -mockwith {return $global:mockedWmi} 
                 Mock Get-Disk -mockwith {return $global:mockedDisk0} -verifiable
                 Mock Get-Partition -mockwith {return $Global:mockedPartition} -verifiable               
 
@@ -133,7 +135,8 @@ try
             }
             context 'Test mismatched AllocationUnitSize' {
                 # verifiable (should be called) mocks 
-                Mock Get-WmiObject -mockwith {return $global:mockedWmi} -verifiable
+                Mock Get-WmiObject -mockwith {return $global:mockedWmi} 
+                Mock Get-CimInstance -mockwith {return $global:mockedWmi} 
                 Mock Get-Disk -mockwith {return $global:mockedDisk0} -verifiable
                 Mock Get-Partition -mockwith {return $Global:mockedPartition} -verifiable
 
@@ -172,6 +175,7 @@ try
                 
                 # mocks that should not be called
                 Mock Get-WmiObject -mockwith {return $global:mockedWmi}
+                Mock Get-CimInstance -mockwith {return $global:mockedWmi}
                 Mock Get-Partition -mockwith {return $Global:mockedPartition}  -verifiable
                 Mock Get-Volume -mockwith {return $global:mockedVolume} -verifiable
                 Mock Set-Disk -mockwith {}
@@ -202,6 +206,7 @@ try
                  
                  # mocks that should not be called 
                  Mock Get-WmiObject -mockwith {return $global:mockedWmi} 
+                 Mock Get-CimInstance -mockwith {return $global:mockedWmi} 
                  Mock Get-Partition -mockwith {return $Global:mockedPartition}  -verifiable 
                  Mock Set-Disk -mockwith {} 
                  Mock Set-Partition -MockWith {}  


### PR DESCRIPTION
Get-WmiObject does not work on Nano Server (as of TP4), so Get/Test-TargetResource failed. Replaced it with Get-CimInstance which seems to work just as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/32)
<!-- Reviewable:end -->