### PR TITLE
Fix identifying volume for Windows 10 Anniversary Edition

### DIFF
--- a/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -90,8 +90,9 @@ function Set-TargetResource
             $Image = Mount-DiskImage -ImagePath $ImagePath -PassThru | Get-Volume
         }
 
-        #Verify drive letter        
-        $CimVolume = Get-CimInstance -ClassName Win32_Volume | where {$_.DeviceId -eq $Image.ObjectId}
+        #Verify drive letter. ObjectId is more verbose than DeviceId in Windows 10 Anniversary Edition, look for
+        #DeviceId in the ObjectId string to match volumes.
+        $CimVolume = Get-CimInstance -ClassName Win32_Volume | Where-Object -FilterScript {$Image.ObjectId.IndexOf($_.DeviceId) -ne -1}
         If($CimVolume.DriveLetter -ne $DriveLetter)
         {
             Write-Verbose "Drive letter does not match expected value. Expected DriveLetter $DriveLetter Actual DriverLetter $($CimVolume.DriveLetter)"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * added test for existing file system and no drive letter assignment to allow simple drive letter assignment in MSFT_xDisk.psm1 
 * added unit test for volume with existing partition and no drive letter assigned for MSFT_xDisk.psm1 
+* xMountImage: Fixed mounting disk images on Windows 10 Anniversary Edition
 
 
 ### 2.6.0.0


### PR DESCRIPTION
ObjectId is more verbose than DeviceId in Windows 10 Anniversary
Edition. In one instance, mounting a disk image and checking the
ObjectId returns
```
{1}\\WIN-56OJJQTNIEP\root/Microsoft/Windows/Storage/Providers_v2\WSP_Volume.ObjectId="{4c19525a-f384-11e4-8044-806e6f6e6963}:VO:\\?\Volume{b153fdb9-87e2-11e5-80b3-005056fce5a0}\"
```
The associated volume has a DeviceId of
```
\\?\Volume{b153fdb9-87e2-11e5-80b3-005056fce5a0}\
```

look for DeviceId in the ObjectId string instead of an exact match to
identify volumes. Fixes #48.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/49)
<!-- Reviewable:end -->
