### PR TITLE
Fix xDiskAccessPath issue when reattaching volume - Fixes #66

### DIFF
--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,0 +1,142 @@
+﻿<#
+    .SYNOPSIS
+    Tests if the current machine is a Nano server.
+#>
+function Test-IsNanoServer
+{
+    [OutputType([Boolean])]
+    [CmdletBinding()]
+    param ()
+
+    return $PSVersionTable.PSEdition -ieq 'Core'
+}
+
+<#
+    .SYNOPSIS
+        Creates and throws an invalid argument exception
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ArgumentName
+        The name of the invalid argument that is causing this error to be thrown
+#>
+function New-InvalidArgumentException
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ArgumentName
+    )
+
+    $argumentException = New-Object -TypeName 'ArgumentException' -ArgumentList @( $Message,
+        $ArgumentName )
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $argumentException, $ArgumentName, 'InvalidArgument', $null )
+    }
+    $errorRecord = New-Object @newObjectParams
+
+    throw $errorRecord
+}
+
+<#
+    .SYNOPSIS
+        Creates and throws an invalid operation exception
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error
+#>
+function New-InvalidOperationException
+{
+    [CmdletBinding()]
+    param
+    (
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $Message)
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException'
+    }
+    elseif ($null -eq $ErrorRecord)
+    {
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
+    }
+    else
+    {
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
+                $ErrorRecord.Exception )
+    }
+
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $invalidOperationException.ToString(), 'MachineStateIncorrect',
+            'InvalidOperation', $null )
+    }
+    $errorRecordToThrow = New-Object @newObjectParams
+    throw $errorRecordToThrow
+}
+
+<#
+    .SYNOPSIS
+        Retrieves the localized string data based on the machine's culture.
+        Falls back to en-US strings if the machine's culture is not supported.
+
+    .PARAMETER ResourceName
+        The name of the resource as it appears before '.strings.psd1' of the localized string file.
+
+        For example:
+            For WindowsOptionalFeature: MSFT_xWindowsOptionalFeature
+            For Service: MSFT_xServiceResource
+            For Registry: MSFT_xRegistryResource
+#>
+function Get-LocalizedData
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ResourceName
+    )
+
+    $resourceDirectory = (Join-Path -Path $PSScriptRoot -ChildPath $ResourceName)
+    $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath $PSUICulture
+
+    if (-not (Test-Path -Path $localizedStringFileLocation))
+    {
+        # Fallback to en-US
+        $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath 'en-US'
+    }
+
+    Import-LocalizedData `
+        -BindingVariable 'localizedData' `
+        -FileName "$ResourceName.strings.psd1" `
+        -BaseDirectory $localizedStringFileLocation
+
+    return $localizedData
+}
+
+Export-ModuleMember -Function @( 'Test-IsNanoServer', 'New-InvalidArgumentException',
+    'New-InvalidOperationException', 'Get-LocalizedData' )

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,6 +1,6 @@
 ﻿<#
     .SYNOPSIS
-    Tests if the current machine is a Nano server.
+        Tests if the current machine is a Nano server.
 #>
 function Test-IsNanoServer
 {
@@ -16,6 +16,20 @@ function Test-IsNanoServer
     }
 
     return $false
+}
+
+<#
+    .SYNOPSIS
+        Tests if the the specified command is found.
+#>
+function Test-Command
+{
+    param
+    (
+        [String] $Name
+    )
+
+    return ($null -ne (Get-Command -Name $Name -ErrorAction Continue 2> $null))
 }
 
 <#

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -4,11 +4,18 @@
 #>
 function Test-IsNanoServer
 {
-    [OutputType([Boolean])]
-    [CmdletBinding()]
-    param ()
+    if (Test-Command -Name Get-ComputerInfo)
+    {
+        $computerInfo = Get-ComputerInfo
 
-    return $PSVersionTable.PSEdition -ieq 'Core'
+        if ("Server" -eq $computerInfo.OsProductType `
+            -and "NanoServer" -eq $computerInfo.OsServerLevel)
+        {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 <#

--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -133,7 +133,9 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding()]
+    # Should process is called in a helper functions but not directly in Set-TargetResource
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -267,10 +267,9 @@ function Set-TargetResource
 
         # After creating the partition it can take a few seconds for it to become writeable
         # Wait for up to 30 seconds for the parition to become writeable
-        $timeout = 30000
-        $start = [DateTime]::Now
-        While ($partition.IsReadOnly `
-            -and ([DateTime]::Now - $start).TotalMilliseconds -lt $timeout)
+        $start = Get-Date
+        $timeout = (Get-Date) + (New-Timespan -Second 30)
+        While ($partition.IsReadOnly -and (Get-Date) -lt $timeout)
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -240,7 +240,7 @@ function Set-TargetResource
     if ($null -eq $assignedPartition)
     {
         # There is no partiton with this access path
-        $createPartition = $false
+        $createPartition = $true
 
         # Are there any partitions defined on this disk?
         if ($partition)
@@ -266,14 +266,14 @@ function Set-TargetResource
                 # A partition matching the required size was found
                 Write-Verbose -Message ($LocalizedData.MatchingPartitionFoundMessage -f `
                     $DiskNumber,$partition.PartitionNumber)
+
+                $createPartition = $false
             }
             else
             {
                 # A partition matching the required size was not found
                 Write-Verbose -Message ($LocalizedData.MatchingPartitionNotFoundMessage -f `
                     $DiskNumber)
-
-                $createPartition = $true
             } # if
         } # if
 

--- a/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -135,7 +135,9 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding()]
+    # Should process is called in a helper functions but not directly in Set-TargetResource
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -234,60 +234,103 @@ function Set-TargetResource
         } # default
     } # switch
 
+    # Get the partitions on the disk
     $partition = Get-Partition `
         -DiskNumber $DiskNumber `
-        -ErrorAction SilentlyContinue |
-            Where-Object -Property AccessPaths -Contains -Value $AccessPath
-
-    $volume = $partition | Get-Volume
+        -ErrorAction SilentlyContinue
 
     # Check if the disk has an existing partition assigned to the access path
-    if ($null -eq $volume)
-    {
-        # There is no partiton with this access path, so create one
-        $partitionParams = @{
-            DiskNumber = $DiskNumber
-        }
+    $assignedPartition = $partition |
+            Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
-        if ($Size)
+    if ($null -eq $assignedPartition)
+    {
+        # There is no partiton with this access path
+        $createPartition = $false
+
+        # Are there any partitions defined on this disk?
+        if ($partition)
         {
-            # Use only a specific size
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($LocalizedData.CreatingPartitionMessage `
-                        -f $DiskNumber,"$($Size/1KB) KB")
-                ) -join '' )
-            $partitionParams["Size"] = $Size
-        }
-        else
-        {
-            # Use the entire disk
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($LocalizedData.CreatingPartitionMessage `
-                        -f $DiskNumber,'all free space')
-                ) -join '' )
-            $partitionParams["UseMaximumSize"] = $true
+            # There are partitions defined - identify if one matches the size required
+            if ($Size)
+            {
+                # Find the first basic partition matching the size
+                $partition = $partition |
+                    Where-Object -Filter { $_.Type -eq 'Basic' -and $_.Size -eq $Size } |
+                    Select-Object -First 1
+            }
+            else
+            {
+                # Find the first basic partition of any size
+                $partition = $partition |
+                    Where-Object -Filter { $_.Type -eq 'Basic' } |
+                    Select-Object -First 1
+            } # if
+
+            if ($partition)
+            {
+                # A partition matching the required size was found
+                Write-Verbose -Message ($LocalizedData.MatchingPartitionFoundMessage -f `
+                    $DiskNumber,$partition.PartitionNumber)
+            }
+            else
+            {
+                # A partition matching the required size was not found
+                Write-Verbose -Message ($LocalizedData.MatchingPartitionNotFoundMessage -f `
+                    $DiskNumber)
+
+                $createPartition = $true
+            } # if
         } # if
 
-        # Create the partition.
-        $partition = New-Partition @partitionParams
-
-        # After creating the partition it can take a few seconds for it to become writeable
-        # Wait for up to 30 seconds for the parition to become writeable
-        $timeout = 30000
-        $start = [DateTime]::Now
-        While ($partition.IsReadOnly `
-            -and ([DateTime]::Now - $start).TotalMilliseconds -lt $timeout)
+        # Do we need to create a new partition?
+        if ($createPartition)
         {
-            Write-Verbose -Message ($LocalizedData.NewPartitionIsReadOnlyMessage -f `
-                $partition.DiskNumber,$partition.PartitionNumber)
+            # Attempt to create a new partition
+            $partitionParams = @{
+                DiskNumber = $DiskNumber
+            }
 
-            Start-Sleep -Seconds 1
+            if ($Size)
+            {
+                # Use only a specific size
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($LocalizedData.CreatingPartitionMessage `
+                            -f $DiskNumber,"$($Size/1KB) KB")
+                    ) -join '' )
+                $partitionParams["Size"] = $Size
+            }
+            else
+            {
+                # Use the entire disk
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($LocalizedData.CreatingPartitionMessage `
+                            -f $DiskNumber,'all free space')
+                    ) -join '' )
+                $partitionParams["UseMaximumSize"] = $true
+            } # if
 
-            # Pull the partition details again to check if it is readonly
-            $partition = $partition | Get-Partition
-        } # while
+            # Create the partition
+            $partition = New-Partition @partitionParams
+
+            # After creating the partition it can take a few seconds for it to become writeable
+            # Wait for up to 30 seconds for the parition to become writeable
+            $timeout = 30000
+            $start = [DateTime]::Now
+            While ($partition.IsReadOnly `
+                -and ([DateTime]::Now - $start).TotalMilliseconds -lt $timeout)
+            {
+                Write-Verbose -Message ($LocalizedData.NewPartitionIsReadOnlyMessage -f `
+                    $partition.DiskNumber,$partition.PartitionNumber)
+
+                Start-Sleep -Seconds 1
+
+                # Pull the partition details again to check if it is readonly
+                $partition = $partition | Get-Partition
+            } # while
+        } # if
 
         if ($partition.IsReadOnly)
         {
@@ -298,6 +341,27 @@ function Set-TargetResource
                     $partition.DiskNumber,$partition.PartitionNumber)
         } # if
 
+        $assignAccessPath = $true
+    }
+    else
+    {
+        # The disk already has a partition on it that is assigned to the access path
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($LocalizedData.PartitionAlreadyAssignedMessage -f `
+                    $AccessPath,$partition.PartitionNumber)
+            ) -join '' )
+
+        $assignAccessPath = $false
+    }
+
+    # Get the Volume on the partition
+    $volume = $partition | Get-Volume
+
+    # Is the volume already formatted?
+    if ($volume.FileSystem -eq '')
+    {
+        # The volume is not formatted
         $volParams = @{
             FileSystem = $FSFormat
             Confirm = $false
@@ -322,25 +386,10 @@ function Set-TargetResource
 
         # Format the volume
         $volume = $partition | Format-Volume @VolParams
-
-        if ($volume)
-        {
-            $null = Add-PartitionAccessPath `
-                -AccessPath $AccessPath `
-                -DiskNumber $DiskNumber `
-                -PartitionNumber $partition.PartitionNumber
-
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($LocalizedData.SuccessfullyInitializedMessage -f $AccessPath)
-                ) -join '' )
-        } # if
     }
     else
     {
-        # The disk already has a partition on it that is assigned to the access path
-
-        # Check the volume format matches
+        # The volume is already formatted
         if ($PSBoundParameters.ContainsKey('FSFormat'))
         {
             # Check the filesystem format
@@ -357,6 +406,7 @@ function Set-TargetResource
             } # if
         } # if
 
+        # Check the volume label
         if ($PSBoundParameters.ContainsKey('FSLabel'))
         {
             # The volume should have a label assigned
@@ -372,6 +422,20 @@ function Set-TargetResource
                 $volume | Set-Volume -NewFileSystemLabel $FSLabel
             } # if
         } # if
+    } # if
+
+    # Assign the access path if it isn't assigned
+    if ($assignAccessPath)
+    {
+        $null = Add-PartitionAccessPath `
+            -AccessPath $AccessPath `
+            -DiskNumber $DiskNumber `
+            -PartitionNumber $partition.PartitionNumber
+
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($LocalizedData.SuccessfullyInitializedMessage -f $AccessPath)
+            ) -join '' )
     } # if
 } # Set-TargetResource
 

--- a/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -311,10 +311,9 @@ function Set-TargetResource
 
             # After creating the partition it can take a few seconds for it to become writeable
             # Wait for up to 30 seconds for the parition to become writeable
-            $timeout = 30000
-            $start = [DateTime]::Now
-            While ($partition.IsReadOnly `
-                -and ([DateTime]::Now - $start).TotalMilliseconds -lt $timeout)
+            $start = Get-Date
+            $timeout = (Get-Date) + (New-Timespan -Second 30)
+            While ($partition.IsReadOnly -and (Get-Date) -lt $timeout)
             {
                 Write-Verbose -Message ($LocalizedData.NewPartitionIsReadOnlyMessage -f `
                     $partition.DiskNumber,$partition.PartitionNumber)

--- a/DSCResources/MSFT_xDiskAccessPath/en-us/MSFT_xDiskAccessPath.strings.psd1
+++ b/DSCResources/MSFT_xDiskAccessPath/en-us/MSFT_xDiskAccessPath.strings.psd1
@@ -24,6 +24,9 @@
     AllocationUnitSizeMismatchMessage = Volume assigned to access path '{0}' has allocation unit size {1} KB does not match expected allocation unit size {2} KB.
     FileSystemFormatMismatch = Volume assigned to access path '{0}' filesystem format '{1}' does not match expected format '{2}'.
     DriveLabelMismatch = Volume assigned to access path '{0}' label '{1}' does not match expected label '{2}'.
+    PartitionAlreadyAssignedMessage = Partition '{1}' is already assigned to access path '{0}'.
+    MatchingPartitionNotFoundMessage = Disk number '{0}' already contains paritions, but none match required size.
+    MatchingPartitionFoundMessage = Disk number '{0}' already contains paritions, and partition '{1}' matches required size.
 
     DiskAlreadyInitializedError = Disk number '{0}' is already initialized with {1}.
     NewParitionIsReadOnlyError = New partition '{1}' on disk '{0}' did not become writable in the expected time.

--- a/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -104,7 +104,9 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding()]
+    # Should process is called in a helper functions but not directly in Set-TargetResource
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -1,20 +1,13 @@
-#region localizeddata
-if (Test-Path "${PSScriptRoot}\${PSUICulture}")
-{
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xMountImage.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
-}
-else
-{
-    #fallback to en-US
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xMountImage.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\en-US"
-}
-#endregion
+# Suppressed as per PSSA Rule Severity guidelines for unit/integration tests:
+# https://github.com/PowerShell/DscResources/blob/master/PSSARuleSeverities.md
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+param ()
+
+Import-Module -Name (Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
+
+# Localized messages for Write-Verbose statements in this resource
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xMountImage'
 
 # Import the common storage functions
 Import-Module -Name ( Join-Path `
@@ -152,7 +145,7 @@ function Set-TargetResource
     if ($Ensure -eq 'Present')
     {
         # Get the normalized DriveLetter (colon removed)
-        $normalizedDriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+        $normalizedDriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
         # The Disk Image should be mounted
         $needsMount = $false
@@ -284,7 +277,7 @@ function Test-TargetResource
     if ($Ensure -eq 'Present')
     {
         # Get the normalized DriveLetter (colon removed)
-        $normalizedDriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+        $normalizedDriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
         # The Disk Image should be mounted
         if ($currentState.Ensure -eq 'Absent')
@@ -414,27 +407,24 @@ function Test-ParameterValid
         if ($PSBoundParameters.ContainsKey('DriveLetter'))
         {
             # The DriveLetter should not be set if Ensure is Absent
-            New-InvalidOperationError `
-                -ErrorId 'InvalidParameterSpecifiedError' `
-                -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+            New-InvalidOperationException `
+                -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                     'Absent','DriveLetter')
         } # if
 
         if ($PSBoundParameters.ContainsKey('StorageType'))
         {
             # The StorageType should not be set if Ensure is Absent
-            New-InvalidOperationError `
-                -ErrorId 'InvalidParameterSpecifiedError' `
-                -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+            New-InvalidOperationException `
+                -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                     'Absent','StorageType')
         } # if
 
         if ($PSBoundParameters.ContainsKey('Access'))
         {
             # The Access should not be set if Ensure is Absent
-            New-InvalidOperationError `
-                -ErrorId 'InvalidParameterSpecifiedError' `
-                -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+            New-InvalidOperationException `
+                -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                     'Absent','Access')
         } # if
     }
@@ -443,23 +433,21 @@ function Test-ParameterValid
         if (-not (Test-Path -Path $ImagePath))
         {
             # The file specified by ImagePath should be found
-            New-InvalidOperationError `
-                -ErrorId 'DiskImageFileNotFoundError' `
-                -ErrorMessage ($LocalizedData.DiskImageFileNotFoundError -f `
+            New-InvalidOperationException `
+                -Message ($LocalizedData.DiskImageFileNotFoundError -f `
                     $ImagePath)
         } # if
 
         if ($PSBoundParameters.ContainsKey('DriveLetter'))
         {
             # Test the Drive Letter to ensure it is valid
-            $normalizedDriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+            $normalizedDriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
         }
         else
         {
             # Drive letter is not specified but Ensure is present.
-            New-InvalidOperationError `
-                -ErrorId 'InvalidParameterNotSpecifiedError' `
-                -ErrorMessage ($LocalizedData.InvalidParameterNotSpecifiedError -f `
+            New-InvalidOperationException `
+                -Message ($LocalizedData.InvalidParameterNotSpecifiedError -f `
                     'Present','DriveLetter')
         } # if
     } # if
@@ -504,7 +492,7 @@ function Mount-DiskImageToLetter
     )
 
     # Get the normalized DriveLetter (colon removed)
-    $normalizedDriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+    $normalizedDriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
     # Mount the Diskimage
     $mountParams = @{ ImagePath = $ImagePath }

--- a/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -69,7 +69,9 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding()]
+    # Should process is called in a helper functions but not directly in Set-TargetResource
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -69,9 +69,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    # Should process is called in a helper functions but not directly in Set-TargetResource
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding()]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -1,20 +1,13 @@
-#region localizeddata
-if (Test-Path "${PSScriptRoot}\${PSUICulture}")
-{
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xWaitForDisk.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
-}
-else
-{
-    #fallback to en-US
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xWaitForDisk.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\en-US"
-}
-#endregion
+# Suppressed as per PSSA Rule Severity guidelines for unit/integration tests:
+# https://github.com/PowerShell/DscResources/blob/master/PSSARuleSeverities.md
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+param ()
+
+Import-Module -Name (Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
+
+# Localized messages for Write-Verbose statements in this resource
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWaitForDisk'
 
 # Import the common storage functions
 Import-Module -Name ( Join-Path `
@@ -120,9 +113,8 @@ function Set-TargetResource
 
     if (-not $diskFound)
     {
-        New-InvalidOperationError `
-            -ErrorId 'DiskNotFoundAfterError' `
-            -ErrorMessage $($LocalizedData.DiskNotFoundAfterError -f $DiskNumber,$RetryCount)
+        New-InvalidOperationException `
+            -Message $($LocalizedData.DiskNotFoundAfterError -f $DiskNumber,$RetryCount)
     } # if
 } # function Set-TargetResource
 

--- a/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
+++ b/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
@@ -72,7 +72,9 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding()]
+    # Should process is called in a helper functions but not directly in Set-TargetResource
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
+++ b/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
@@ -1,20 +1,13 @@
-#region localizeddata
-if (Test-Path "${PSScriptRoot}\${PSUICulture}")
-{
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xWaitForVolume.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
-}
-else
-{
-    #fallback to en-US
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename MSFT_xWaitForVolume.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\en-US"
-}
-#endregion
+# Suppressed as per PSSA Rule Severity guidelines for unit/integration tests:
+# https://github.com/PowerShell/DscResources/blob/master/PSSARuleSeverities.md
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+param ()
+
+Import-Module -Name (Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
+
+# Localized messages for Write-Verbose statements in this resource
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWaitForVolume'
 
 # Import the common storage functions
 Import-Module -Name ( Join-Path `
@@ -54,7 +47,7 @@ function Get-TargetResource
         ) -join '' )
 
     # Validate the DriveLetter parameter
-    $DriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+    $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
     $returnValue = @{
         DriveLetter      = $DriveLetter
@@ -96,7 +89,7 @@ function Set-TargetResource
         ) -join '' )
 
     # Validate the DriveLetter parameter
-    $DriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+    $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
     $volumeFound = $false
 
@@ -130,9 +123,8 @@ function Set-TargetResource
 
     if (-not $volumeFound)
     {
-        New-InvalidOperationError `
-            -ErrorId 'VolumeNotFoundAfterError' `
-            -ErrorMessage $($LocalizedData.VolumeNotFoundAfterError -f $DriveLetter,$RetryCount)
+        New-InvalidOperationException `
+            -Message $($LocalizedData.VolumeNotFoundAfterError -f $DriveLetter,$RetryCount)
     } # if
 } # function Set-TargetResource
 
@@ -169,7 +161,7 @@ function Test-TargetResource
         ) -join '' )
 
     # Validate the DriveLetter parameter
-    $DriveLetter = Test-DriveLetter -DriveLetter $DriveLetter
+    $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
     # This command forces a refresh of the PS Drive subsystem.
     # So triggers any "missing" drives to show up.

--- a/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
+++ b/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
@@ -72,9 +72,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    # Should process is called in a helper functions but not directly in Set-TargetResource
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '')]
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding()]
     param
     (
         [parameter(Mandatory)]

--- a/DSCResources/StorageCommon/StorageCommon.psm1
+++ b/DSCResources/StorageCommon/StorageCommon.psm1
@@ -1,88 +1,8 @@
-﻿#region localizeddata
-if (Test-Path "${PSScriptRoot}\${PSUICulture}")
-{
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename StorageCommon.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
-}
-else
-{
-    #fallback to en-US
-    Import-LocalizedData `
-        -BindingVariable LocalizedData `
-        -Filename StorageCommon.strings.psd1 `
-        -BaseDirectory "${PSScriptRoot}\en-US"
-}
-#endregion
+﻿Import-Module -Name (Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
+                               -ChildPath 'CommonResourceHelper.psm1')
 
-<#
-    .SYNOPSIS
-    Throws an InvalidOperation custom exception.
-
-    .PARAMETER ErrorId
-    The error Id of the exception.
-
-    .PARAMETER ErrorMessage
-    The error message text to set in the exception.
-#>
-function New-InvalidOperationError
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorId,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorMessage
-    )
-
-    $exception = New-Object -TypeName System.InvalidOperationException `
-        -ArgumentList $ErrorMessage
-    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-        -ArgumentList $exception, $ErrorId, $errorCategory, $null
-    throw $errorRecord
-} # end function New-InvalidOperationError
-
-<#
-    .SYNOPSIS
-    Throws an InvalidArgument custom exception.
-
-    .PARAMETER ErrorId
-    The error Id of the exception.
-
-    .PARAMETER ErrorMessage
-    The error message text to set in the exception.
-#>
-function New-InvalidArgumentError
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorId,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorMessage
-    )
-
-    $exception = New-Object -TypeName System.ArgumentException `
-        -ArgumentList $ErrorMessage
-    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-        -ArgumentList $exception, $ErrorId, $errorCategory, $null
-    throw $errorRecord
-} # end function New-InvalidArgumentError
+# Localized messages for Write-Verbose statements in this resource
+$script:localizedData = Get-LocalizedData -ResourceName 'StorageCommon'
 
 <#
     .SYNOPSIS
@@ -94,7 +14,7 @@ function New-InvalidArgumentError
     .PARAMETER Colon
     Will ensure the returned string will include or exclude a colon.
 #>
-function Test-DriveLetter
+function Assert-DriveLetterValid
 {
     [CmdletBinding()]
     [OutputType([String])]
@@ -113,9 +33,9 @@ function Test-DriveLetter
     if (-not $Matches)
     {
         # DriveLetter format is invalid
-        New-InvalidArgumentError `
-            -ErrorId 'InvalidDriveLetterFormatError' `
-            -ErrorMessage $($LocalizedData.InvalidDriveLetterFormatError -f $DriveLetter)
+        New-InvalidArgumentException `
+            -Message $($LocalizedData.InvalidDriveLetterFormatError -f $DriveLetter) `
+            -ArgumentName 'DriveLetter'
     }
     # This is the drive letter without a colon
     $DriveLetter = $Matches.Groups[1].Value
@@ -124,7 +44,7 @@ function Test-DriveLetter
         $DriveLetter = $DriveLetter + ':'
     } # if
     return $DriveLetter
-} # end function Test-DriveLetter
+} # end function Assert-DriveLetterValid
 
 <#
     .SYNOPSIS
@@ -138,7 +58,7 @@ function Test-DriveLetter
     .PARAMETER Slash
     Will ensure the returned path will include or exclude a slash.
 #>
-function Test-AccessPath
+function Assert-AccessPathValid
 {
     [CmdletBinding()]
     [OutputType([String])]
@@ -156,9 +76,9 @@ function Test-AccessPath
     if (-not (Test-Path -Path $AccessPath -PathType Container))
     {
         # AccessPath is invalid
-        New-InvalidArgumentError `
-            -ErrorId 'InvalidAccessPathError' `
-            -ErrorMessage $($LocalizedData.InvalidAccessPathError -f $AccessPath)
+        New-InvalidArgumentException `
+            -Message $($LocalizedData.InvalidAccessPathError -f $AccessPath) `
+            -ArgumentName 'AccessPath'
     } # if
 
     # Remove or Add the trailing slash
@@ -178,4 +98,6 @@ function Test-AccessPath
     } # if
 
     return $AccessPath
-} # end function Test-AccessPath
+} # end function Assert-AccessPathValid
+
+Export-ModuleMember -Function @( 'Assert-DriveLetterValid', 'Assert-AccessPathValid' )

--- a/Examples/Sample_InitializeDataDisk.ps1
+++ b/Examples/Sample_InitializeDataDisk.ps1
@@ -12,7 +12,7 @@ Configuration Sample_DataDisk
         {
              DiskNumber = 2
              RetryIntervalSec = 60
-             Count = 60
+             RetryCount = 60
         }
 
         xDisk GVolume

--- a/Examples/Sample_InitializeDataDiskWithAccessPath.ps1
+++ b/Examples/Sample_InitializeDataDiskWithAccessPath.ps1
@@ -12,7 +12,7 @@ Configuration Sample_DataDiskwithAccessPath
         {
              DiskNumber = 2
              RetryIntervalSec = 60
-             Count = 60
+             RetryCount = 60
         }
 
         xDiskAccessPath DataVolume

--- a/Examples/Sample_xMountImage_DismountISO.ps1
+++ b/Examples/Sample_xMountImage_DismountISO.ps1
@@ -4,7 +4,6 @@ configuration Sample_xMountImage_DismountISO
     Import-DscResource -ModuleName xStorage
     xMountImage ISO
     {
-        Name = 'SQL Disk'
         ImagePath = 'c:\Sources\SQL.iso'
         DriveLetter = 'S'
         Ensure = 'Absent'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master)
-
 # xStorage
+
+[![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master)
 
 The **xStorage** module is a part of the Windows PowerShell Desired State Configuration (DSC) Resource Kit, which is a collection of DSC Resources.
 
@@ -21,90 +21,97 @@ If you would like to modify this module, feel free. When modifying, please updat
 
 For more information about Windows PowerShell Desired State Configuration, check out the blog posts on the [PowerShell Blog](http://blogs.msdn.com/b/powershell/) ([this](http://blogs.msdn.com/b/powershell/archive/2013/11/01/configuration-in-a-devops-world-windows-powershell-desired-state-configuration.aspx) is a good starting point). There are also great community resources, such as [PowerShell.org](http://powershell.org/wp/tag/dsc/), or [PowerShell Magazine](http://www.powershellmagazine.com/tag/dsc/). For more information on the DSC Resource Kit, checkout [this blog post](http://go.microsoft.com/fwlink/?LinkID=389546).
 
-Installation
-------------
+## Installation
 
 To install the **xStorage** module
 
--   If you are using WMF4 / PowerShell Version 4: Unzip the content under $env:ProgramFilesWindowsPowerShellModules folder
+- If you are using WMF4 / PowerShell Version 4: Unzip the content under $env:ProgramFilesWindowsPowerShellModules folder
 
--   If you are using WMF5 Preview: From an elevated PowerShell session run ```Install-Module xStorage```
+- If you are using WMF5 Preview: From an elevated PowerShell session run ```Install-Module xStorage```
 
 To confirm installation
 
--   Run Get-DSCResource to see that the resources listed above are among the DSC Resources displayed
+- Run Get-DSCResource to see that the resources listed above are among the DSC Resources displayed
 
-## Contributing
+## How to Contribute
 
-Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
+If you would like to contribute to this repository, please read the DSC Resource Kit [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
 ## Resources
 
-* **xMountImage**: used to mount or unmount an ISO/VHD disk image. It can be mounted as read-only (ISO, VHD, VHDx) or read/write (VHD, VHDx).
-* **xDisk**: used to initialize, format and mount the partition as a drive letter.
-* **xDiskAccessPath**: used to initialize, format and mount the partition to a folder access path.
-* **xWaitForDisk** wait for a disk to become available.
-* **xWaitForVolume** wait for a drive to be mounted and become available.
+- **xMountImage**: used to mount or unmount an ISO/VHD disk image. It can be mounted as read-only (ISO, VHD, VHDx) or read/write (VHD, VHDx).
+- **xDisk**: used to initialize, format and mount the partition as a drive letter.
+- **xDiskAccessPath**: used to initialize, format and mount the partition to a folder access path.
+- **xWaitForDisk** wait for a disk to become available.
+- **xWaitForVolume** wait for a drive to be mounted and become available.
 
 ### xMountImage
 
-* **`[String]` ImagePath** _(Key)_: Specifies the path of the VHD or ISO file.
-* **`[String]` DriveLetter** _(Write)_: Specifies the drive letter to mount this VHD or ISO to. Must be empty if Ensure is Absent.
-* **`[String]` StorageType** _(Write)_: Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension. { ISO | VHD | VHDx | VHDSet }.
-* **`[String]` Access** _(Write)_: Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide. { ReadOnly | ReadWrite }.
-* **`[String]` Ensure** _(Write)_: Determines whether the VHD or ISO should be mounted or not. { *Present* | Absent }. Defaults to Present.
+- **`[String]` ImagePath** _(Key)_: Specifies the path of the VHD or ISO file.
+- **`[String]` DriveLetter** _(Write)_: Specifies the drive letter to mount this VHD or ISO to. Must be empty if Ensure is Absent.
+- **`[String]` StorageType** _(Write)_: Specifies the storage type of a file. If the StorageType parameter is not specified, then the storage type is determined by file extension. { ISO | VHD | VHDx | VHDSet }.
+- **`[String]` Access** _(Write)_: Allows a VHD file to be mounted in read-only or read-write mode. ISO files are mounted in read-only mode regardless of what parameter value you provide. { ReadOnly | ReadWrite }.
+- **`[String]` Ensure** _(Write)_: Determines whether the VHD or ISO should be mounted or not. { *Present* | Absent }. Defaults to Present.
 
 ### xDisk
 
-* **`[String]` DriveLetter** _(Key)_: Specifies the preferred letter to assign to the disk volume.
-* **`[UInt32]` DiskNumber** _(Required)_: Specifies the disk number for which disk to modify.
-* **`[Uint64]` Size** _(Write)_: Specifies the size of new volume (use all available space on disk if not provided).
-* **`[String]` FSLabel** _(Write)_: Define volume label if required.
-* **`[UInt32]` AllocationUnitSize** _(Write)_: Specifies the allocation unit size to use when formatting the volume.
-* **`[String]` FSFormat** _(Write)_: Define volume label if required. { *NTFS* | ReFS }. Defaults to NTFS.
+- **`[String]` DriveLetter** _(Key)_: Specifies the preferred letter to assign to the disk volume.
+- **`[UInt32]` DiskNumber** _(Required)_: Specifies the disk number for which disk to modify.
+- **`[Uint64]` Size** _(Write)_: Specifies the size of new volume (use all available space on disk if not provided).
+- **`[String]` FSLabel** _(Write)_: Define volume label if required.
+- **`[UInt32]` AllocationUnitSize** _(Write)_: Specifies the allocation unit size to use when formatting the volume.
+- **`[String]` FSFormat** _(Write)_: Define volume label if required. { *NTFS* | ReFS }. Defaults to NTFS.
 
 ### xDiskAccessPath
 
-* **`[String]` AccessPath** _(Key)_: Specifies the access path folder to the assign the disk volume to.
-* **`[UInt32]` DiskNumber** _(Required)_: Specifies the disk number for which disk to modify.
-* **`[Uint64]` Size** _(Write)_: Specifies the size of new volume (use all available space on disk if not provided).
-* **`[String]` FSLabel** _(Write)_: Define volume label if required.
-* **`[UInt32]` AllocationUnitSize** _(Write)_: Specifies the allocation unit size to use when formatting the volume.
-* **`[String]` FSFormat** _(Write)_: Define volume label if required. { *NTFS* | ReFS }. Defaults to NTFS.
+- **`[String]` AccessPath** _(Key)_: Specifies the access path folder to the assign the disk volume to.
+- **`[UInt32]` DiskNumber** _(Required)_: Specifies the disk number for which disk to modify.
+- **`[Uint64]` Size** _(Write)_: Specifies the size of new volume (use all available space on disk if not provided).
+- **`[String]` FSLabel** _(Write)_: Define volume label if required.
+- **`[UInt32]` AllocationUnitSize** _(Write)_: Specifies the allocation unit size to use when formatting the volume.
+- **`[String]` FSFormat** _(Write)_: Define volume label if required. { *NTFS* | ReFS }. Defaults to NTFS.
 
 ### xWaitforDisk
 
-* **`[UInt32]` DiskNumber** _(Key)_: Specifies the identifier for which disk to wait for.
-* **`[UInt64]` RetryIntervalSec** _(Write)_: Specifies the number of seconds to wait for the disk to become available. Defaults to 10 seconds.
-* **`[UInt32]` RetryCount** _(Write)_: The number of times to loop the retry interval while waiting for the disk. Defaults to 60 times.
+- **`[UInt32]` DiskNumber** _(Key)_: Specifies the identifier for which disk to wait for.
+- **`[UInt64]` RetryIntervalSec** _(Write)_: Specifies the number of seconds to wait for the disk to become available. Defaults to 10 seconds.
+- **`[UInt32]` RetryCount** _(Write)_: The number of times to loop the retry interval while waiting for the disk. Defaults to 60 times.
 
 ### xWaitForVolume
 
-* **`[String]` DriveLetter** _(Key)_: Specifies the name of the drive to wait for.
-* **`[UInt64]` RetryIntervalSec** _(Write)_: Specifies the number of seconds to wait for the drive to become available. Defaults to 10 seconds.
-* **`[UInt32]` RetryCount** _(Write)_: The number of times to loop the retry interval while waiting for the drive. Defaults to 60 times.
+- **`[String]` DriveLetter** _(Key)_: Specifies the name of the drive to wait for.
+- **`[UInt64]` RetryIntervalSec** _(Write)_: Specifies the number of seconds to wait for the drive to become available. Defaults to 10 seconds.
+- **`[UInt32]` RetryCount** _(Write)_: The number of times to loop the retry interval while waiting for the drive. Defaults to 60 times.
 
 ## Versions
 
 ### Unreleased
 
+- Updated readme.md to remove markdown best practice rule violations.
+- Updated readme.md to match DSCResources/DscResource.Template/README.md.
+- xDiskAccessPath:
+  - Fix bug when re-attaching disk after mount point removed or detatched.
+  - Additional log entries added for improved diagnostics.
+  - Additional integration tests added.
+
 ### 2.8.0.0
-* added test for existing file system and no drive letter assignment to allow simple drive letter assignment in MSFT_xDisk.psm1
-* added unit test for volume with existing partition and no drive letter assigned for MSFT_xDisk.psm1
-* xMountImage: Fixed mounting disk images on Windows 10 Anniversary Edition
-* Updated to meet HQRM guidelines.
-* Moved all strings into localization files.
-* Fixed examples to import xStorage module.
-* Fixed Readme.md layout issues.
-* xWaitForDisk:
+
+- added test for existing file system and no drive letter assignment to allow simple drive letter assignment in MSFT_xDisk.psm1
+- added unit test for volume with existing partition and no drive letter assigned for MSFT_xDisk.psm1
+- xMountImage: Fixed mounting disk images on Windows 10 Anniversary Edition
+- Updated to meet HQRM guidelines.
+- Moved all strings into localization files.
+- Fixed examples to import xStorage module.
+- Fixed Readme.md layout issues.
+- xWaitForDisk:
   - Added support for setting DriveLetter parameter with or without colon.
   - MOF Class version updated to 1.0.0.0.
-* xWaitForVolume:
+- xWaitForVolume:
   - Added new resource.
-* StorageCommon:
+- StorageCommon:
   - Added helper function module.
   - Corrected name of unit tests file.
-* xDisk:
+- xDisk:
   - Added validation of DriveLetter parameter.
   - Added support for setting DriveLetter parameter with or without colon.
   - Removed obfuscation of drive/partition errors by eliminating try/catch block.
@@ -117,59 +124,60 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - Added additional unit tests to Get-TargetResource.
   - Fixed bug in Get-TargetResource when disk did not contain any partitions.
   - Added missing cmdletbinding() to functions.
-* xMountImage (Breaking Change):
+- xMountImage (Breaking Change):
   - Removed Name parameter (Breaking Change)
   - Added validation of DriveLetter parameter.
   - Added support for setting DriveLetter parameter with or without colon.
   - MOF Class version updated to 1.0.0.0.
   - Enabled mounting of VHD/VHDx/VHDSet disk images.
   - Added StorageType and Access parameters to allow mounting VHD and VHDx disks as read/write.
-* xDiskAccessPath:
+- xDiskAccessPath:
   - Added new resource.
   - Added support for changing/setting volume label.
 
 ### 2.7.0.0
-* Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+
+- Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 
 ### 2.6.0.0
 
-* MSFT_xDisk: Replaced Get-WmiObject with Get-CimInstance
+- MSFT_xDisk: Replaced Get-WmiObject with Get-CimInstance
 
 ### 2.5.0.0
 
-* added test for existing file system to allow simple drive letter assignment in MSFT_xDisk.psm1
-* modified Test verbose message to correctly reflect blocksize value in MSFT_xDisk.psm1 line 217
-* added unit test for new volume with out existing partition for MSFT_xDisk.psm1
-* Fixed error propagation
+- added test for existing file system to allow simple drive letter assignment in MSFT_xDisk.psm1
+- modified Test verbose message to correctly reflect blocksize value in MSFT_xDisk.psm1 line 217
+- added unit test for new volume with out existing partition for MSFT_xDisk.psm1
+- Fixed error propagation
 
 ### 2.4.0.0
 
-* Fixed bug where AllocationUnitSize was not used
+- Fixed bug where AllocationUnitSize was not used
 
 ### 2.3.0.0
 
-* Added support for `AllocationUnitSize` in `xDisk`.
+- Added support for `AllocationUnitSize` in `xDisk`.
 
 ### 2.2.0.0
 
-* Updated documentation: changed parameter name Count to RetryCount in xWaitForDisk resource
+- Updated documentation: changed parameter name Count to RetryCount in xWaitForDisk resource
 
 ### 2.1.0.0
 
-* Fixed encoding
+- Fixed encoding
 
 ### 2.0.0.0
 
-* Breaking change: Added support for following properties: DriveLetter, Size, FSLabel. DriveLetter is a new key property.
+- Breaking change: Added support for following properties: DriveLetter, Size, FSLabel. DriveLetter is a new key property.
 
 ### 1.0.0.0
 
 This module was previously named **xDisk**, the version is regressing to a "1.0.0.0" release with the addition of xMountImage.
 
-* Initial release of xStorage module with following resources (contains resources from deprecated xDisk module):
-* xDisk (from xDisk)
-* xMountImage
-* xWaitForDisk (from xDisk)
+- Initial release of xStorage module with following resources (contains resources from deprecated xDisk module):
+- xDisk (from xDisk)
+- xMountImage
+- xWaitForDisk (from xDisk)
 
 
 ## Examples
@@ -265,7 +273,7 @@ DataDisk -outputpath C:\Sample_DataDiskwithAccessPath
 Start-DscConfiguration -Path C:\Sample_DataDiskwithAccessPath -Wait -Force -Verbose
 ```
 
-### Example - xMountImage
+### Example - xMountImage ISO
 
 This configuration will mount an ISO file as drive S:.
 
@@ -313,7 +321,7 @@ Sample_xMountImage_DismountISO
 Start-DscConfiguration -Path Sample_xMountImage_DismountISO -Wait -Force -Verbose
 ```
 
-### Example - xMountImage
+### Example - xMountImage VHD
 
 This configuration will mount a VHD file and wait for it to become available.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,14 @@ If you would like to contribute to this repository, please read the DSC Resource
   - Fix bug when re-attaching disk after mount point removed or detatched.
   - Additional log entries added for improved diagnostics.
   - Additional integration tests added.
-- Converted integration tests to use TestDrive as working folder.
+- Converted integration tests to use ```$TestDrive``` as working folder or ```temp``` folder when persistence across tests is required.
+- Suppress ```PSUseShouldProcessForStateChangingFunctions``` rule violations in resources.
+- Rename ```Test-AccessPath``` function to ```Assert-AccessPathValid```.
+- Rename ```Test-DriveLetter``` function to ```Assert-DriveLetterValid```.
+- Added ```CommonResourceHelper.psm1``` module (based on PSDscResources).
+- Added ```CommonTestsHelper.psm1``` module  (based on PSDscResources).
+- Converted all modules to load localization data using ```Get-LocalizedData``` from CommonResourceHelper.
+- Converted all exception calls and tests to use functions in ```CommonResourceHelper.psm1``` and ```CommonTestsHelper.psm1``` respectively.
 
 ### 2.8.0.0
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ If you would like to contribute to this repository, please read the DSC Resource
 - Added ```CommonTestsHelper.psm1``` module  (based on PSDscResources).
 - Converted all modules to load localization data using ```Get-LocalizedData``` from CommonResourceHelper.
 - Converted all exception calls and tests to use functions in ```CommonResourceHelper.psm1``` and ```CommonTestsHelper.psm1``` respectively.
+- Fixed examples:
+  - Sample_InitializeDataDisk.ps1
+  - Sample_InitializeDataDiskWithAccessPath.ps1
+  - Sample_xMountImage_DismountISO.ps1
 
 ### 2.8.0.0
 
@@ -207,7 +211,7 @@ Configuration Sample_DataDisk
         {
              DiskNumber = 2
              RetryIntervalSec = 60
-             Count = 60
+             RetryCount = 60
         }
 
         xDisk GVolume
@@ -256,7 +260,7 @@ Configuration Sample_DataDiskwithAccessPath
         {
              DiskNumber = 2
              RetryIntervalSec = 60
-             Count = 60
+             RetryCount = 60
         }
 
         xDiskAccessPath DataVolume
@@ -318,7 +322,6 @@ configuration Sample_xMountImage_DismountISO
     Import-DscResource -ModuleName xStorage
     xMountImage ISO
     {
-        Name = 'SQL Disk'
         ImagePath = 'c:\Sources\SQL.iso'
         DriveLetter = 'S'
         Ensure = 'Absent'

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If you would like to contribute to this repository, please read the DSC Resource
   - Fix bug when re-attaching disk after mount point removed or detatched.
   - Additional log entries added for improved diagnostics.
   - Additional integration tests added.
+  - Improve timeout loop.
 - Converted integration tests to use ```$TestDrive``` as working folder or ```temp``` folder when persistence across tests is required.
 - Suppress ```PSUseShouldProcessForStateChangingFunctions``` rule violations in resources.
 - Rename ```Test-AccessPath``` function to ```Assert-AccessPathValid```.
@@ -105,6 +106,8 @@ If you would like to contribute to this repository, please read the DSC Resource
   - Sample_InitializeDataDisk.ps1
   - Sample_InitializeDataDiskWithAccessPath.ps1
   - Sample_xMountImage_DismountISO.ps1
+- xDisk:
+  - Improve timeout loop.
 
 ### 2.8.0.0
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If you would like to contribute to this repository, please read the DSC Resource
   - Fix bug when re-attaching disk after mount point removed or detatched.
   - Additional log entries added for improved diagnostics.
   - Additional integration tests added.
+- Converted integration tests to use TestDrive as working folder.
 
 ### 2.8.0.0
 

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -38,7 +38,7 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk and assign a Drive Letter' {
             # Create a VHDx and attach it to the computer
-            $VHDPath = Join-Path -Path $TestEnvironment.WorkingFolder `
+            $VHDPath = Join-Path -Path $TestDrive `
                 -ChildPath 'TestDisk.vhdx'
             New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
             Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
@@ -67,9 +67,9 @@ try
                     }
 
                     & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -38,7 +38,7 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk and assign an Access Path' {
             # Create a VHDx and attach it to the computer
-            $VHDPath = Join-Path -Path $TestEnvironment.WorkingFolder `
+            $VHDPath = Join-Path -Path $TestDrive `
                 -ChildPath 'TestDisk.vhdx'
             New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
             Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
@@ -71,9 +71,9 @@ try
                     }
 
                     & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
@@ -119,9 +119,9 @@ try
                     }
 
                     & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -81,7 +81,6 @@ try
             It 'should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
-            #endregion
 
             It 'Should have set the resource and all the parameters should match' {
                 $current = Get-DscConfiguration | Where-Object {
@@ -92,6 +91,61 @@ try
                 $current.FSLabel          | Should Be $FSLabel
             }
 
+            # Create a file on the new disk to ensure it still exists after reattach
+            $testFilePath = Join-Path -Path $AccessPath -ChildPath 'IntTestFile.txt'
+            Set-Content `
+                -Path $testFilePath `
+                -Value 'Test' `
+                -NoNewline
+
+            # This test will ensure the disk can be remounted if the access path is removed.
+            Remove-PartitionAccessPath `
+                -DiskNumber $Disk.DiskNumber `
+                -PartitionNumber 2 `
+                -AccessPath $AccessPath
+
+            It 'Should compile without throwing' {
+                {
+                    # This is so that the
+                    $ConfigData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName    = 'localhost'
+                                AccessPath  = $AccessPath
+                                DiskNumber  = $Disk.Number
+                                FSLabel     = $FSLabel
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -ConfigurationData $ConfigData
+                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should not throw
+            }
+
+            It 'should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskNumber       | Should Be $Disk.DiskNumber
+                $current.AccessPath       | Should Be "$($AccessPath)\"
+                $current.FSLabel          | Should Be $FSLabel
+            }
+
+            It 'Should contain the test file' {
+                Test-Path -Path $testFilePath        | Should Be $true
+                Get-Content -Path $testFilePath -Raw | Should Be 'Test'
+            }
+            #endregion
+
+            # Clean up
             Remove-PartitionAccessPath `
                 -DiskNumber $Disk.DiskNumber `
                 -PartitionNumber 2 `

--- a/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
@@ -61,9 +61,9 @@ try
             It 'Should compile without throwing' {
                 {
                     & "$($script:DSCResourceName)_Mount_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
@@ -96,9 +96,9 @@ try
             It 'Should compile without throwing' {
                 {
                     & "$($script:DSCResourceName)_Dismount_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -41,7 +41,7 @@ try
     $DriveLetter = [char](([int][char]$LastDrive)+1)
 
     # Create a VHDx with a partition
-    $VHDPath = Join-Path -Path $TestEnvironment.WorkingFolder `
+    $VHDPath = Join-Path -Path $TestDrive `
         -ChildPath 'TestDisk.vhdx'
     $null = New-VHD -Path $VHDPath -SizeBytes 10GB -Dynamic
     $null = Mount-DiskImage -ImagePath $VHDPath
@@ -72,9 +72,9 @@ try
             It 'Should compile without throwing' {
                 {
                     & "$($script:DSCResourceName)_Mount_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
@@ -107,9 +107,9 @@ try
             It 'Should compile without throwing' {
                 {
                     & "$($script:DSCResourceName)_Dismount_Config" `
-                        -OutputPath $TestEnvironment.WorkingFolder `
+                        -OutputPath $TestDrive `
                         -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder `
+                    Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -41,7 +41,7 @@ try
     $DriveLetter = [char](([int][char]$LastDrive)+1)
 
     # Create a VHDx with a partition
-    $VHDPath = Join-Path -Path $TestDrive `
+    $VHDPath = Join-Path -Path $ENV:Temp `
         -ChildPath 'TestDisk.vhdx'
     $null = New-VHD -Path $VHDPath -SizeBytes 10GB -Dynamic
     $null = Mount-DiskImage -ImagePath $VHDPath

--- a/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
@@ -29,8 +29,8 @@ try
             #region DEFAULT TESTS
             It 'Should compile without throwing' {
                 {
-                    & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                    & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
 

--- a/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
@@ -29,8 +29,8 @@ try
             #region DEFAULT TESTS
             It 'Should compile without throwing' {
                 {
-                    & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                    & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
 

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -1,0 +1,86 @@
+﻿<#
+    .SYNOPSIS
+        Returns an invalid argument exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ArgumentName
+        The name of the invalid argument that is causing this error to be thrown
+#>
+function Get-InvalidArgumentRecord
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ArgumentName
+    )
+
+    $argumentException = New-Object -TypeName 'ArgumentException' -ArgumentList @( $Message,
+        $ArgumentName )
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $argumentException, $ArgumentName, 'InvalidArgument', $null )
+    }
+    return New-Object @newObjectParams
+}
+
+<#
+    .SYNOPSIS
+        Returns an invalid operation exception object
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error
+#>
+function Get-InvalidOperationRecord
+{
+    [CmdletBinding()]
+    param
+    (
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Message,
+
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($null -eq $Message)
+    {
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException'
+    }
+    elseif ($null -eq $ErrorRecord)
+    {
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
+    }
+    else
+    {
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
+                $ErrorRecord.Exception )
+    }
+
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $invalidOperationException.ToString(), 'MachineStateIncorrect',
+            'InvalidOperation', $null )
+    }
+    return New-Object @newObjectParams
+}
+
+Export-ModuleMember -Function `
+    Get-InvalidArgumentRecord, `
+    Get-InvalidOperationRecord

--- a/Tests/Unit/MSFT_xDiskAssignPath.tests.ps1
+++ b/Tests/Unit/MSFT_xDiskAssignPath.tests.ps1
@@ -86,11 +86,25 @@ try
                     $script:testAccessPath
                 )
                 Size = 123
+                PartitionNumber = 1
+            }
+
+        $script:mockedPartitionNoAccess = [pscustomobject] @{
+                AccessPaths = @(
+                    '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
+                )
+                Size = 123
+                PartitionNumber = 1
             }
 
         $script:mockedVolume = [pscustomobject] @{
                 FileSystemLabel = 'myLabel'
                 FileSystem = 'NTFS'
+            }
+
+        $script:mockedVolumeUnformatted = [pscustomobject] @{
+                FileSystemLabel = ''
+                FileSystem = ''
             }
 
         $script:mockedVolumeReFS = [pscustomobject] @{
@@ -374,17 +388,24 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartition } `
+                    -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
 
                 Mock `
                     -CommandName Format-Volume `
                     -Verifiable
 
+                Mock `
+                    -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
-                Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
 
                 It 'Should not throw' {
                     {
@@ -402,10 +423,10 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
                 }
             }
 
@@ -431,17 +452,24 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartition } `
+                    -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
 
                 Mock `
                     -CommandName Format-Volume `
                     -Verifiable
 
+                Mock `
+                    -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
-                Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
 
                 It 'Should not throw' {
                     {
@@ -459,10 +487,10 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
                 }
             }
 
@@ -492,16 +520,23 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartition } `
+                    -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
 
                 Mock `
                     -CommandName Format-Volume `
                     -Verifiable
 
+                Mock `
+                    -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
                 # mocks that should not be called
-                Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
 
                 It 'Should not throw' {
                     {
@@ -519,10 +554,10 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
                 }
             }
 
@@ -548,17 +583,24 @@ try
 
                 Mock `
                     -CommandName New-Partition `
-                    -MockWith { $script:mockedPartition } `
+                    -MockWith { $script:mockedPartitionNoAccess } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolumeUnformatted } `
                     -Verifiable
 
                 Mock `
                     -CommandName Format-Volume `
                     -Verifiable
 
+                Mock `
+                    -CommandName Add-PartitionAccessPath `
+                    -Verifiable
+
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
-                Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
 
                 It 'Should not throw' {
                     {
@@ -576,10 +618,10 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
                 }
             }
 
@@ -605,14 +647,21 @@ try
                     -Verifiable
 
                 Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolumeUnformatted } `
+                    -Verifiable
+
+                Mock `
                     -CommandName Format-Volume `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Add-PartitionAccessPath `
                     -Verifiable
 
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
-                Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
 
                 It 'Should not throw' {
                     {
@@ -630,10 +679,10 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 1
                 }
             }
 
@@ -656,7 +705,7 @@ try
                 Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
                 Mock -CommandName Get-Volume
-                Mock -CommandName Set-Partition
+                Mock -CommandName Add-PartitionAccessPath
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.DiskAlreadyInitializedError -f `
@@ -681,7 +730,7 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 0
                     Assert-MockCalled -CommandName New-Partition -Times 0
                     Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 0
                 }
             }
 
@@ -711,7 +760,7 @@ try
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
                 Mock -CommandName Format-Volume
-                Mock -CommandName Set-Partition
+                Mock -CommandName Add-PartitionAccessPath
 
                 It 'Should not throw' {
                     {
@@ -732,7 +781,7 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 0
                     Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 0
                 }
             }
 
@@ -766,7 +815,7 @@ try
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
                 Mock -CommandName Format-Volume
-                Mock -CommandName Set-Partition
+                Mock -CommandName Add-PartitionAccessPath
 
                 It 'Should not throw' {
                     {
@@ -788,8 +837,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 0
                     Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
                     Assert-MockCalled -CommandName Set-Volume -Times 1
+                    Assert-MockCalled -CommandName Add-PartitionAccessPath -Times 0
                 }
             }
         }

--- a/Tests/Unit/MSFT_xMountImage.tests.ps1
+++ b/Tests/Unit/MSFT_xMountImage.tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xStorage'
 $script:DSCResourceName    = 'MSFT_xMountImage'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1')
+
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -25,33 +27,7 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $script:DSCResourceName {
-        # Function to create a exception object for testing output exceptions
-        function Get-InvalidOperationError
-        {
-            [CmdletBinding()]
-            param
-            (
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorId,
-
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorMessage
-            )
-
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $ErrorMessage
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $ErrorId, $errorCategory, $null
-            return $errorRecord
-        } # end function Get-InvalidOperationError
-
         #region Pester Test Initialization
-
         $script:DriveLetter = 'X'
 
         # ISO Related Mocks
@@ -790,9 +766,8 @@ try
         Describe 'MSFT_xMountImage\Test-ParameterValid' {
             Context 'DriveLetter passed, ensure is Absent' {
                 It 'Should throw InvalidParameterSpecifiedError exception' {
-                    $errorRecord = Get-InvalidOperationError `
-                        -ErrorId 'InvalidParameterSpecifiedError' `
-                        -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                             'Absent','DriveLetter')
 
                     {
@@ -807,9 +782,8 @@ try
 
             Context 'StorageType passed, ensure is Absent' {
                 It 'Should throw InvalidParameterSpecifiedError exception' {
-                    $errorRecord = Get-InvalidOperationError `
-                        -ErrorId 'InvalidParameterSpecifiedError' `
-                        -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                             'Absent','StorageType')
 
                     {
@@ -824,9 +798,8 @@ try
 
             Context 'Access passed, ensure is Absent' {
                 It 'Should throw InvalidParameterSpecifiedError exception' {
-                    $errorRecord = Get-InvalidOperationError `
-                        -ErrorId 'InvalidParameterSpecifiedError' `
-                        -ErrorMessage ($LocalizedData.InvalidParameterSpecifiedError -f `
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.InvalidParameterSpecifiedError -f `
                             'Absent','Access')
 
                     {
@@ -856,9 +829,8 @@ try
                         -CommandName Test-Path `
                         -MockWith { $false }
 
-                    $errorRecord = Get-InvalidOperationError `
-                        -ErrorId 'DiskImageFileNotFoundError' `
-                        -ErrorMessage ($LocalizedData.DiskImageFileNotFoundError -f `
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.DiskImageFileNotFoundError -f `
                             $script:DiskImageISOPath)
 
                     {
@@ -876,9 +848,8 @@ try
                         -CommandName Test-Path `
                         -MockWith { $true }
 
-                    $errorRecord = Get-InvalidOperationError `
-                        -ErrorId 'InvalidParameterNotSpecifiedError' `
-                        -ErrorMessage ($LocalizedData.InvalidParameterNotSpecifiedError -f `
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.InvalidParameterNotSpecifiedError -f `
                             'Present','DriveLetter')
 
                     {

--- a/Tests/Unit/MSFT_xWaitForDisk.tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForDisk.tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xStorage'
 $script:DSCResourceName    = 'MSFT_xWaitForDisk'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1')
+
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -25,31 +27,6 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $script:DSCResourceName {
-        # Function to create a exception object for testing output exceptions
-        function Get-InvalidOperationError
-        {
-            [CmdletBinding()]
-            param
-            (
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorId,
-
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorMessage
-            )
-
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $ErrorMessage
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $ErrorId, $errorCategory, $null
-            return $errorRecord
-        } # end function Get-InvalidOperationError
-
         #region Pester Test Initialization
         $mockedDisk0 = [pscustomobject] @{
             Number = 0
@@ -106,9 +83,8 @@ try
                 # verifiable (Should Be called) mocks
                 Mock Get-Disk -MockWith { } -Verifiable
 
-                $errorRecord = Get-InvalidOperationError `
-                    -ErrorId 'DiskNotFoundAfterError' `
-                    -ErrorMessage $($LocalizedData.DiskNotFoundAfterError `
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message $($LocalizedData.DiskNotFoundAfterError `
                         -f $disk0Parameters.DiskNumber,$disk0Parameters.RetryCount)
 
                 It 'should throw DiskNotFoundAfterError' {

--- a/Tests/Unit/MSFT_xWaitForVolume.tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForVolume.tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xStorage'
 $script:DSCResourceName    = 'MSFT_xWaitForVolume'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1')
+
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -25,31 +27,6 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $script:DSCResourceName {
-        # Function to create a exception object for testing output exceptions
-        function Get-InvalidOperationError
-        {
-            [CmdletBinding()]
-            param
-            (
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorId,
-
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorMessage
-            )
-
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $ErrorMessage
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $ErrorId, $errorCategory, $null
-            return $errorRecord
-        } # end function Get-InvalidOperationError
-
         #region Pester Test Initialization
         $mockedDriveC = [pscustomobject] @{
             DriveLetter      = 'C'
@@ -106,9 +83,8 @@ try
                 # verifiable (Should Be called) mocks
                 Mock Get-Volume -MockWith { } -Verifiable
 
-                $errorRecord = Get-InvalidOperationError `
-                    -ErrorId 'VolumeNotFoundAfterError' `
-                    -ErrorMessage $($LocalizedData.VolumeNotFoundAfterError `
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message $($LocalizedData.VolumeNotFoundAfterError `
                         -f $driveCParameters.DriveLetter,$driveCParameters.RetryCount)
 
                 It 'should throw VolumeNotFoundAfterError' {

--- a/Tests/Unit/StorageCommon.tests.ps1
+++ b/Tests/Unit/StorageCommon.tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xStorage'
 $script:DSCResourceName    = 'StorageCommon'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1')
+
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -26,54 +28,6 @@ try
         $LocalizedData
     }
 
-    function Get-InvalidOperationError
-    {
-        [CmdletBinding()]
-        param
-        (
-            [Parameter(Mandatory)]
-            [ValidateNotNullOrEmpty()]
-            [System.String]
-            $ErrorId,
-
-            [Parameter(Mandatory)]
-            [ValidateNotNullOrEmpty()]
-            [System.String]
-            $ErrorMessage
-        )
-
-        $exception = New-Object -TypeName System.InvalidOperationException `
-            -ArgumentList $ErrorMessage
-        $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-            -ArgumentList $exception, $ErrorId, $errorCategory, $null
-        return $errorRecord
-    } # end function Get-InvalidOperationError
-
-    function Get-InvalidArgumentError
-    {
-        [CmdletBinding()]
-        param
-        (
-            [Parameter(Mandatory)]
-            [ValidateNotNullOrEmpty()]
-            [System.String]
-            $ErrorId,
-
-            [Parameter(Mandatory)]
-            [ValidateNotNullOrEmpty()]
-            [System.String]
-            $ErrorMessage
-        )
-
-        $exception = New-Object -TypeName System.ArgumentException `
-            -ArgumentList $ErrorMessage
-        $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-            -ArgumentList $exception, $ErrorId, $errorCategory, $null
-        return $errorRecord
-    } # end function Get-InvalidArgumentError
-
     #region Pester Test Initialization
     $driveLetterGood = 'C'
     $driveLetterGoodwithColon = 'C:'
@@ -86,66 +40,66 @@ try
     $accessPathBad = 'c:\Bad'
     #endregion
 
-    #region Function Test-DriveLetter
-    Describe "StorageCommon\Test-DriveLetter" {
+    #region Function Assert-DriveLetterValid
+    Describe "StorageCommon\Assert-DriveLetterValid" {
         Context 'drive letter is good, has no colon and colon is not required' {
             It "should return '$driveLetterGood'" {
-                Test-DriveLetter -DriveLetter $driveLetterGood | Should Be $driveLetterGood
+                Assert-DriveLetterValid -DriveLetter $driveLetterGood | Should Be $driveLetterGood
             }
         }
 
         Context 'drive letter is good, has no colon but colon is required' {
             It "should return '$driveLetterGoodwithColon'" {
-                Test-DriveLetter -DriveLetter $driveLetterGood -Colon | Should Be $driveLetterGoodwithColon
+                Assert-DriveLetterValid -DriveLetter $driveLetterGood -Colon | Should Be $driveLetterGoodwithColon
             }
         }
 
         Context 'drive letter is good, has a colon but colon is not required' {
             It "should return '$driveLetterGood'" {
-                Test-DriveLetter -DriveLetter $driveLetterGoodwithColon | Should Be $driveLetterGood
+                Assert-DriveLetterValid -DriveLetter $driveLetterGoodwithColon | Should Be $driveLetterGood
             }
         }
 
         Context 'drive letter is good, has a colon and colon is required' {
             It "should return '$driveLetterGoodwithColon'" {
-                Test-DriveLetter -DriveLetter $driveLetterGoodwithColon -Colon | Should Be $driveLetterGoodwithColon
+                Assert-DriveLetterValid -DriveLetter $driveLetterGoodwithColon -Colon | Should Be $driveLetterGoodwithColon
             }
         }
 
         Context 'drive letter is non alpha' {
-            $errorRecord = Get-InvalidArgumentError `
-                -ErrorId 'InvalidDriveLetterFormatError' `
-                -ErrorMessage $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBad)
+            $errorRecord = Get-InvalidArgumentRecord `
+                -Message $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBad) `
+                -ArgumentName 'DriveLetter'
 
             It 'should throw InvalidDriveLetterFormatError' {
-                { Test-DriveLetter -DriveLetter $driveLetterBad } | Should Throw $errorRecord
+                { Assert-DriveLetterValid -DriveLetter $driveLetterBad } | Should Throw $errorRecord
             }
         }
 
         Context 'drive letter has a bad colon location' {
-            $errorRecord = Get-InvalidArgumentError `
-                -ErrorId 'InvalidDriveLetterFormatError' `
-                -ErrorMessage $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBadColon)
+            $errorRecord = Get-InvalidArgumentRecord `
+                -Message $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBadColon) `
+                -ArgumentName 'DriveLetter'
 
             It 'should throw InvalidDriveLetterFormatError' {
-                { Test-DriveLetter -DriveLetter $driveLetterBadColon } | Should Throw $errorRecord
+                { Assert-DriveLetterValid -DriveLetter $driveLetterBadColon } | Should Throw $errorRecord
             }
         }
 
         Context 'drive letter is too long' {
-            $errorRecord = Get-InvalidArgumentError `
-                -ErrorId 'InvalidDriveLetterFormatError' `
-                -ErrorMessage $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBadTooLong)
+            $errorRecord = Get-InvalidArgumentRecord `
+                -Message $($LocalizedData.InvalidDriveLetterFormatError -f $driveLetterBadTooLong) `
+                -ArgumentName 'DriveLetter'
 
             It 'should throw InvalidDriveLetterFormatError' {
-                { Test-DriveLetter -DriveLetter $driveLetterBadTooLong } | Should Throw $errorRecord
+                { Assert-DriveLetterValid -DriveLetter $driveLetterBadTooLong } | Should Throw $errorRecord
             }
         }
     }
     #endregion
 
-    #region Function Test-AccessPath
-    Describe "StorageCommon\Test-AccessPath" {
+    #region Function Assert-AccessPathValid
+    Describe "StorageCommon\Assert-AccessPathValid" {
         Mock `
             -CommandName Test-Path `
             -ModuleName StorageCommon `
@@ -153,25 +107,25 @@ try
 
         Context 'path is found, trailing slash included, not required' {
             It "should return '$accessPathGood'" {
-                Test-AccessPath -AccessPath $accessPathGoodWithSlash | Should Be $accessPathGood
+                Assert-AccessPathValid -AccessPath $accessPathGoodWithSlash | Should Be $accessPathGood
             }
         }
 
         Context 'path is found, trailing slash included, required' {
             It "should return '$accessPathGoodWithSlash'" {
-                Test-AccessPath -AccessPath $accessPathGoodWithSlash -Slash | Should Be $accessPathGoodWithSlash
+                Assert-AccessPathValid -AccessPath $accessPathGoodWithSlash -Slash | Should Be $accessPathGoodWithSlash
             }
         }
 
         Context 'path is found, trailing slash not included, required' {
             It "should return '$accessPathGoodWithSlash'" {
-                Test-AccessPath -AccessPath $accessPathGood -Slash | Should Be $accessPathGoodWithSlash
+                Assert-AccessPathValid -AccessPath $accessPathGood -Slash | Should Be $accessPathGoodWithSlash
             }
         }
 
         Context 'path is found, trailing slash not included, not required' {
             It "should return '$accessPathGood'" {
-                Test-AccessPath -AccessPath $accessPathGood | Should Be $accessPathGood
+                Assert-AccessPathValid -AccessPath $accessPathGood | Should Be $accessPathGood
             }
         }
 
@@ -181,12 +135,12 @@ try
             -MockWith { $False }
 
         Context 'drive is not found' {
-            $errorRecord = Get-InvalidArgumentError `
-                -ErrorId 'InvalidAccessPathError' `
-                -ErrorMessage $($LocalizedData.InvalidAccessPathError -f $accessPathBad)
+            $errorRecord = Get-InvalidArgumentRecord `
+                -Message $($LocalizedData.InvalidAccessPathError -f $accessPathBad) `
+                -ArgumentName 'AccessPath'
 
             It 'should throw InvalidAccessPathError' {
-                { Test-AccessPath `
+                { Assert-AccessPathValid `
                     -AccessPath $accessPathBad } | Should Throw $errorRecord
             }
         }

--- a/tests/unit/MSFT_xDisk.tests.ps1
+++ b/tests/unit/MSFT_xDisk.tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xStorage'
 $script:DSCResourceName    = 'MSFT_xDisk'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1')
+
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -25,31 +27,6 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $script:DSCResourceName {
-        # Function to create a exception object for testing output exceptions
-        function Get-InvalidOperationError
-        {
-            [CmdletBinding()]
-            param
-            (
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorId,
-
-                [Parameter(Mandatory)]
-                [ValidateNotNullOrEmpty()]
-                [System.String]
-                $ErrorMessage
-            )
-
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $ErrorMessage
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $ErrorId, $errorCategory, $null
-            return $errorRecord
-        } # end function Get-InvalidOperationError
-
         #region Pester Test Initialization
         $script:testDriveLetter = 'G'
 
@@ -652,9 +629,8 @@ try
                 Mock -CommandName Get-Volume
                 Mock -CommandName Set-Partition
 
-                $errorRecord = Get-InvalidOperationError `
-                    -ErrorId 'DiskAlreadyInitializedError' `
-                    -ErrorMessage ($LocalizedData.DiskAlreadyInitializedError -f `
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.DiskAlreadyInitializedError -f `
                         0,$script:mockedDisk0Mbr.PartitionStyle)
 
                 It 'Should throw DiskAlreadyInitializedError' {


### PR DESCRIPTION
This PR:
- Fixes #66 
- Fixes #67
- Fixes #68 

These are some PSSA violations still in xDisk and xDiskAccessPath:
```
- MSFT_xDisk.psm1 (Line 96): File 'MSFT_xDisk.psm1' uses WMI cmdlet. For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
- MSFT_xDisk.psm1 (Line 533): File 'MSFT_xDisk.psm1' uses WMI cmdlet. For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
- MSFT_xDiskAccessPath.psm1 (Line 98): File 'MSFT_xDiskAccessPath.psm1' uses WMI cmdlet. For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
- MSFT_xDiskAccessPath.psm1 (Line 570): File 'MSFT_xDiskAccessPath.psm1' uses WMI cmdlet. For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
```

The WMI cmdlets should be able to be removed because they are fallback cmdlets if CIM does not work. Removing these may prevent older the resources from working in older OS's though. Unfortunately there were no code comments stating why the WMI cmdlets were included. @kwirkykat , @mbreakey3 - what is the thinking of the DSC Team on this?

This change contains the following fixes:
```
- Updated readme.md to remove markdown best practice rule violations.
- Updated readme.md to match DSCResources/DscResource.Template/README.md.
- xDiskAccessPath:
  - Fix bug when re-attaching disk after mount point removed or detatched.
  - Additional log entries added for improved diagnostics.
  - Additional integration tests added.
- Converted integration tests to use ```$TestDrive``` as working folder or ```temp``` folder when persistence across tests is required.
- Suppress ```PSUseShouldProcessForStateChangingFunctions``` rule violations in resources.
- Rename ```Test-AccessPath``` function to ```Assert-AccessPathValid```.
- Rename ```Test-DriveLetter``` function to ```Assert-DriveLetterValid```.
- Added ```CommonResourceHelper.psm1``` module (based on PSDscResources).
- Added ```CommonTestsHelper.psm1``` module  (based on PSDscResources).
- Converted all modules to load localization data using ```Get-LocalizedData``` from CommonResourceHelper.
- Converted all exception calls and tests to use functions in ```CommonResourceHelper.psm1``` and ```CommonTestsHelper.psm1``` respectively.
- Fixed examples:
  - Sample_InitializeDataDisk.ps1
  - Sample_InitializeDataDiskWithAccessPath.ps1
  - Sample_xMountImage_DismountISO.ps1
```

The changes made to xDiskAccessPath could be also ported to xDisk and it would resolve #25 . I'll raise a separate issue to address this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/70)
<!-- Reviewable:end -->
