### PR TITLE
Fixed Unit tests and allowed Pester 4.0.3 usage - Fixes #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - Opted in to Markdown and Example tests.
 - Added CodeCov.io support.
 - Removed requirement on using Pester 3.4.6 because Pester bug fixed in 4.0.3.
-- Fixed unit tests for MSFT_xDiskAccessPath resource to be compatible with Pester 4.0.3.
+- Fixed unit tests for MSFT_xDiskAccessPath resource to be compatible with
+  Pester 4.0.3.
 
 ## 2.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed support for WMI cmdlets.
 - Opted in to Markdown and Example tests.
 - Added CodeCov.io support.
+- Removed requirement on using Pester 3.4.6 because Pester bug fixed in 4.0.3.
 
 ## 2.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Opted in to Markdown and Example tests.
 - Added CodeCov.io support.
 - Removed requirement on using Pester 3.4.6 because Pester bug fixed in 4.0.3.
+- Fixed unit tests for MSFT_xDiskAccessPath resource to be compatible with Pester 4.0.3.
 
 ## 2.9.0.0
 

--- a/Tests/Unit/MSFT_xDiskAccessPath.tests.ps1
+++ b/Tests/Unit/MSFT_xDiskAccessPath.tests.ps1
@@ -755,6 +755,7 @@ try
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
                 Mock -CommandName Add-PartitionAccessPath
 
@@ -806,6 +807,7 @@ try
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
                 Mock -CommandName Add-PartitionAccessPath
 
@@ -862,6 +864,7 @@ try
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
                 Mock -CommandName Add-PartitionAccessPath
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,7 @@ install:
         $moduleName = 'xStorage'
         $mainModuleFolder = "Modules\$moduleName"
         Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
-        Invoke-AppveyorInstallTask `
-            -PesterMaximumVersion 3.4.6
+        Invoke-AppveyorInstallTask
 
 #---------------------------------#
 #      build configuration        #


### PR DESCRIPTION
Removed requirement on using Pester 3.4.6 because Pester bug fixed in 4.0.3.
Fixed unit tests for MSFT_xDiskAccessPath resource to be compatible with Pester 4.0.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/83)
<!-- Reviewable:end -->
