### PR TITLE
Partition resize and destructive switch implemented. Fixes #11, #50 and #89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   - Fixed style violations in xDisk.
   - Fixed issue when creating multiple partitions on a single disk with no size
     specified - See [Issue 86](https://github.com/PowerShell/xStorage/issues/86).
+  - Added parameter AllowDestructive to allow partition resize/reformat - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
+  - Added parameter ClearDisk to allow clearing a disk of partitions when AllowDestructive is $true - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
   - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to
     enable it to contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
   - Fixed style violations in xDisk.
   - Fixed issue when creating multiple partitions on a single disk with no size
     specified - See [Issue 86](https://github.com/PowerShell/xStorage/issues/86).
-  - Added parameter AllowDestructive to allow partition resize/reformat - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
-  - Added parameter ClearDisk to allow clearing a disk of partitions when AllowDestructive is $true - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
+  - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
+  - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
   - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to
     enable it to contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -7,13 +7,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
-                                                     -ChildPath 'StorageDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+            -ChildPath 'StorageDsc.Common.psm1'))
 
 # Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
-                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+            -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -431,142 +431,144 @@ function Set-TargetResource
 
         if ($assignedPartition.Size -ne $Size)
         {
-            if ($AllowDestructive -and $FSFormat -eq 'ReFS')
+            if ($AllowDestructive)
             {
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($localizedData.ResizeRefsNotPossible `
-                                -f $DriveLetter, $assignedPartition.Size, $Size)
-                    ) -join '' )
-            }
-
-            if ($AllowDestructive -and $FSFormat -ne 'ReFS')
-            {
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($localizedData.SizeMismatchCorrection `
-                                -f $DriveLetter, $assignedPartition.Size, $Size)
-                    ) -join '' )                
-                
-                $supportedSize = ($assignedPartition | Get-PartitionSupportedSize)
-            
-                if ($size -gt $supportedSize.SizeMax)
-                {
-                    New-InvalidArgumentException -Message ( @(
-                            "$($MyInvocation.MyCommand): "
-                            $($localizedData.FreeSpaceViolationError `
-                                    -f $DriveLetter, $assignedPartition.Size, $Size, $supportedSize.SizeMax)
-                        ) -join '' ) -ArgumentName 'Size' -ErrorAction Stop
-                }
-
-                $assignedPartition | Resize-Partition -Size $Size
-            }
-        }
-    }
-
-    # Get the Volume on the partition
-    $volume = $partition | Get-Volume
-
-    # Is the volume already formatted?
-    if ($volume.FileSystem -eq '')
-    {
-        # The volume is not formatted
-        $volParams = @{
-            FileSystem = $FSFormat
-            Confirm    = $false
-        }
-
-        if ($FSLabel)
-        {
-            # Set the File System label on the new volume
-            $volParams["NewFileSystemLabel"] = $FSLabel
-        } # if
-
-        if ($AllocationUnitSize)
-        {
-            # Set the Allocation Unit Size on the new volume
-            $volParams["AllocationUnitSize"] = $AllocationUnitSize
-        } # if
-
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.FormattingVolumeMessage -f $volParams.FileSystem)
-            ) -join '' )
-
-        # Format the volume
-        $volume = $partition | Format-Volume @VolParams
-    }
-    else
-    {
-        # The volume is already formatted
-        if ($PSBoundParameters.ContainsKey('FSFormat'))
-        {
-            # Check the filesystem format
-            $fileSystem = $volume.FileSystem
-            if ($fileSystem -ne $FSFormat)
-            {
-                # The file system format does not match
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($localizedData.FileSystemFormatMismatch -f `
-                                $DriveLetter, $fileSystem, $FSFormat)
-                    ) -join '' )
-
-                if ($AllowDestructive)
+                if ($FSFormat -eq 'ReFS')
                 {
                     Write-Verbose -Message ( @(
                             "$($MyInvocation.MyCommand): "
-                            $($localizedData.VolumeFormatInProgress -f `
+                            $($localizedData.ResizeRefsNotPossible `
+                                    -f $DriveLetter, $assignedPartition.Size, $Size)
+                        ) -join '' )
+            
+                }
+                else
+                {
+                    Write-Verbose -Message ( @(
+                            "$($MyInvocation.MyCommand): "
+                            $($localizedData.SizeMismatchCorrection `
+                                    -f $DriveLetter, $assignedPartition.Size, $Size)
+                        ) -join '' )                
+                
+                    $supportedSize = ($assignedPartition | Get-PartitionSupportedSize)
+            
+                    if ($size -gt $supportedSize.SizeMax)
+                    {
+                        New-InvalidArgumentException -Message ( @(
+                                "$($MyInvocation.MyCommand): "
+                                $($localizedData.FreeSpaceViolationError `
+                                        -f $DriveLetter, $assignedPartition.Size, $Size, $supportedSize.SizeMax)
+                            ) -join '' ) -ArgumentName 'Size' -ErrorAction Stop
+                    }
+
+                    $assignedPartition | Resize-Partition -Size $Size
+                }
+            }
+        }
+
+        # Get the Volume on the partition
+        $volume = $partition | Get-Volume
+
+        # Is the volume already formatted?
+        if ($volume.FileSystem -eq '')
+        {
+            # The volume is not formatted
+            $volParams = @{
+                FileSystem = $FSFormat
+                Confirm    = $false
+            }
+
+            if ($FSLabel)
+            {
+                # Set the File System label on the new volume
+                $volParams["NewFileSystemLabel"] = $FSLabel
+            } # if
+
+            if ($AllocationUnitSize)
+            {
+                # Set the Allocation Unit Size on the new volume
+                $volParams["AllocationUnitSize"] = $AllocationUnitSize
+            } # if
+
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.FormattingVolumeMessage -f $volParams.FileSystem)
+                ) -join '' )
+
+            # Format the volume
+            $volume = $partition | Format-Volume @VolParams
+        }
+        else
+        {
+            # The volume is already formatted
+            if ($PSBoundParameters.ContainsKey('FSFormat'))
+            {
+                # Check the filesystem format
+                $fileSystem = $volume.FileSystem
+                if ($fileSystem -ne $FSFormat)
+                {
+                    # The file system format does not match
+                    Write-Verbose -Message ( @(
+                            "$($MyInvocation.MyCommand): "
+                            $($localizedData.FileSystemFormatMismatch -f `
                                     $DriveLetter, $fileSystem, $FSFormat)
                         ) -join '' )
 
-                    $formatParam = @{
-                        FileSystem = $FSFormat
-                        Force      = $true
-                    }
-
-                    if ($PSBoundParameters.ContainsKey('AllocationUnitSize'))
+                    if ($AllowDestructive)
                     {
-                        $formatParam.Add('AllocationUnitSize', $AllocationUnitSize)
+                        Write-Verbose -Message ( @(
+                                "$($MyInvocation.MyCommand): "
+                                $($localizedData.VolumeFormatInProgress -f `
+                                        $DriveLetter, $fileSystem, $FSFormat)
+                            ) -join '' )
+
+                        $formatParam = @{
+                            FileSystem = $FSFormat
+                            Force      = $true
+                        }
+
+                        if ($PSBoundParameters.ContainsKey('AllocationUnitSize'))
+                        {
+                            $formatParam.Add('AllocationUnitSize', $AllocationUnitSize)
+                        }
+
+                        $Volume | Format-Volume @formatParam
                     }
-
-                    $Volume | Format-Volume @formatParam
-                }
+                } # if
             } # if
-        } # if
 
-        # Check the volume label
-        if ($PSBoundParameters.ContainsKey('FSLabel'))
-        {
-            # The volume should have a label assigned
-            if ($volume.FileSystemLabel -ne $FSLabel)
+            # Check the volume label
+            if ($PSBoundParameters.ContainsKey('FSLabel'))
             {
-                # The volume lable needs to be changed because it is different.
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($localizedData.ChangingVolumeLabelMessage `
-                                -f $DriveLetter, $FSLabel)
-                    ) -join '' )
+                # The volume should have a label assigned
+                if ($volume.FileSystemLabel -ne $FSLabel)
+                {
+                    # The volume lable needs to be changed because it is different.
+                    Write-Verbose -Message ( @(
+                            "$($MyInvocation.MyCommand): "
+                            $($localizedData.ChangingVolumeLabelMessage `
+                                    -f $DriveLetter, $FSLabel)
+                        ) -join '' )
 
-                $volume | Set-Volume -NewFileSystemLabel $FSLabel
+                    $volume | Set-Volume -NewFileSystemLabel $FSLabel
+                } # if
             } # if
         } # if
-    } # if
 
-    # Assign the Drive Letter if it isn't assigned
-    if ($assignDriveLetter -and ($partition.DriveLetter -ne $DriveLetter))
-    {
-        $null = $partition | Set-Partition -NewDriveLetter $DriveLetter
+        # Assign the Drive Letter if it isn't assigned
+        if ($assignDriveLetter -and ($partition.DriveLetter -ne $DriveLetter))
+        {
+            $null = $partition | Set-Partition -NewDriveLetter $DriveLetter
 
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.SuccessfullyInitializedMessage -f $DriveLetter)
-            ) -join '' )
-    } # if
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.SuccessfullyInitializedMessage -f $DriveLetter)
+                ) -join '' )
+        } # if
     
-}# Set-TargetResource
+    }# Set-TargetResource
 
-<#
+    <#
     .SYNOPSIS
     Tests if the disk is initialized, the partion exists and the drive letter is assigned.
 
@@ -597,208 +599,208 @@ function Set-TargetResource
     .PARAMETER ClearDisk
     Specifies if the disks partition schema should be removed entirely, even if data and oem partitions are present. Only possible with AllowDestructive enabled.
 #>
-function Test-TargetResource
-{
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $DriveLetter,
-
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $DiskId,
-
-        [Parameter()]
-        [ValidateSet('Number', 'UniqueId')]
-        [System.String]
-        $DiskIdType = 'Number',
-
-        [Parameter()]
-        [System.UInt64]
-        $Size,
-
-        [Parameter()]
-        [System.String]
-        $FSLabel,
-
-        [Parameter()]
-        [System.UInt32]
-        $AllocationUnitSize,
-
-        [Parameter()]
-        [ValidateSet('NTFS', 'ReFS')]
-        [System.String]
-        $FSFormat = 'NTFS',
-
-        [Parameter()]
-        [System.Boolean]
-        $AllowDestructive,
-
-        [Parameter()]
-        [System.Boolean]
-        $ClearDisk
-    )
-
-    Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.TestingDiskMessage -f $DiskIdType, $DiskId, $DriveLetter)
-        ) -join '' )
-
-    # Validate the DriveLetter parameter
-    $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
-
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.CheckDiskInitializedMessage -f $DiskIdType, $DiskId)
-        ) -join '' )
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
-
-    if (-not $disk)
+    function Test-TargetResource
     {
+        [CmdletBinding()]
+        [OutputType([System.Boolean])]
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.String]
+            $DriveLetter,
+
+            [Parameter(Mandatory = $true)]
+            [System.String]
+            $DiskId,
+
+            [Parameter()]
+            [ValidateSet('Number', 'UniqueId')]
+            [System.String]
+            $DiskIdType = 'Number',
+
+            [Parameter()]
+            [System.UInt64]
+            $Size,
+
+            [Parameter()]
+            [System.String]
+            $FSLabel,
+
+            [Parameter()]
+            [System.UInt32]
+            $AllocationUnitSize,
+
+            [Parameter()]
+            [ValidateSet('NTFS', 'ReFS')]
+            [System.String]
+            $FSFormat = 'NTFS',
+
+            [Parameter()]
+            [System.Boolean]
+            $AllowDestructive,
+
+            [Parameter()]
+            [System.Boolean]
+            $ClearDisk
+        )
+
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotFoundMessage -f $DiskIdType, $DiskId)
+                $($localizedData.TestingDiskMessage -f $DiskIdType, $DiskId, $DriveLetter)
             ) -join '' )
 
-        return $false
-    } # if
+        # Validate the DriveLetter parameter
+        $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
-    if ($disk.IsOffline)
-    {
+        $diskIdParameter = @{
+            $DiskIdType = $DiskId
+        }
+
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotOnlineMessage -f $DiskIdType, $DiskId)
+                $($localizedData.CheckDiskInitializedMessage -f $DiskIdType, $DiskId)
             ) -join '' )
 
-        return $false
-    } # if
+        $disk = Get-Disk `
+            @diskIdParameter `
+            -ErrorAction SilentlyContinue
 
-    if ($disk.IsReadOnly)
-    {
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskReadOnlyMessage -f $DiskIdType, $DiskId)
-            ) -join '' )
-
-        return $false
-    } # if
-
-    if ($disk.PartitionStyle -ne 'GPT')
-    {
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotGPTMessage -f $DiskIdType, $DiskId, $Disk.PartitionStyle)
-            ) -join '' )
-
-        return $false
-    } # if
-
-    $partition = Get-Partition `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
-    if ($partition.DriveLetter -ne $DriveLetter)
-    {
-        Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.DriveLetterNotFoundMessage -f $DriveLetter)
-            ) -join '' )
-
-        return $false
-    } # if
-
-    # Drive size
-    if ($Size)
-    {
-        if ($partition.Size -ne $Size)
-        {
-            # The partition size mismatches
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($localizedData.SizeMismatchMessage `
-                            -f $DriveLetter, $Partition.Size, $Size)
-                ) -join '' )
-
-            if ($AllowDestructive)
-            {
-                return $false
-            }
-        } # if
-    } # if
-
-    $blockSize = (Get-CimInstance `
-            -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" `
-            -ErrorAction SilentlyContinue).BlockSize
-
-    if ($blockSize -gt 0 -and $AllocationUnitSize -ne 0)
-    {
-        if ($AllocationUnitSize -ne $blockSize)
-        {
-            # The allocation unit size mismatches
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($localizedData.AllocationUnitSizeMismatchMessage `
-                            -f $DriveLetter, $($blockSize.BlockSize / 1KB), $($AllocationUnitSize / 1KB))
-                ) -join '' )
-
-            if ($AllowDestructive)
-            {
-                return $false
-            }
-        } # if
-    } # if
-
-    # Get the volume so the properties can be checked
-    $volume = Get-Volume `
-        -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
-
-    if ($PSBoundParameters.ContainsKey('FSFormat'))
-    {
-        # Check the filesystem format
-        $fileSystem = $volume.FileSystem
-        if ($fileSystem -ne $FSFormat)
+        if (-not $disk)
         {
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($localizedData.FileSystemFormatMismatch `
-                            -f $DriveLetter, $fileSystem, $FSFormat)
-                ) -join '' )
-
-            if ($AllowDestructive)
-            {
-                return $false
-            }
-        } # if
-    } # if
-
-    if ($PSBoundParameters.ContainsKey('FSLabel'))
-    {
-        # Check the volume label
-        $label = $volume.FileSystemLabel
-        if ($label -ne $FSLabel)
-        {
-            # The assigned volume label is different and needs updating
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($localizedData.DriveLabelMismatch `
-                            -f $DriveLetter, $label, $FSLabel)
+                    $($localizedData.DiskNotFoundMessage -f $DiskIdType, $DiskId)
                 ) -join '' )
 
             return $false
         } # if
-    } # if
 
-    return $true
-} # Test-TargetResource
+        if ($disk.IsOffline)
+        {
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DiskNotOnlineMessage -f $DiskIdType, $DiskId)
+                ) -join '' )
 
-Export-ModuleMember -Function *-TargetResource
+            return $false
+        } # if
+
+        if ($disk.IsReadOnly)
+        {
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DiskReadOnlyMessage -f $DiskIdType, $DiskId)
+                ) -join '' )
+
+            return $false
+        } # if
+
+        if ($disk.PartitionStyle -ne 'GPT')
+        {
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DiskNotGPTMessage -f $DiskIdType, $DiskId, $Disk.PartitionStyle)
+                ) -join '' )
+
+            return $false
+        } # if
+
+        $partition = Get-Partition `
+            -DriveLetter $DriveLetter `
+            -ErrorAction SilentlyContinue
+        if ($partition.DriveLetter -ne $DriveLetter)
+        {
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DriveLetterNotFoundMessage -f $DriveLetter)
+                ) -join '' )
+
+            return $false
+        } # if
+
+        # Drive size
+        if ($Size)
+        {
+            if ($partition.Size -ne $Size)
+            {
+                # The partition size mismatches
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($localizedData.SizeMismatchMessage `
+                                -f $DriveLetter, $Partition.Size, $Size)
+                    ) -join '' )
+
+                if ($AllowDestructive)
+                {
+                    return $false
+                }
+            } # if
+        } # if
+
+        $blockSize = (Get-CimInstance `
+                -Query "SELECT BlockSize from Win32_Volume WHERE DriveLetter = '$($DriveLetter):'" `
+                -ErrorAction SilentlyContinue).BlockSize
+
+        if ($blockSize -gt 0 -and $AllocationUnitSize -ne 0)
+        {
+            if ($AllocationUnitSize -ne $blockSize)
+            {
+                # The allocation unit size mismatches
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($localizedData.AllocationUnitSizeMismatchMessage `
+                                -f $DriveLetter, $($blockSize.BlockSize / 1KB), $($AllocationUnitSize / 1KB))
+                    ) -join '' )
+
+                if ($AllowDestructive)
+                {
+                    return $false
+                }
+            } # if
+        } # if
+
+        # Get the volume so the properties can be checked
+        $volume = Get-Volume `
+            -DriveLetter $DriveLetter `
+            -ErrorAction SilentlyContinue
+
+        if ($PSBoundParameters.ContainsKey('FSFormat'))
+        {
+            # Check the filesystem format
+            $fileSystem = $volume.FileSystem
+            if ($fileSystem -ne $FSFormat)
+            {
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($localizedData.FileSystemFormatMismatch `
+                                -f $DriveLetter, $fileSystem, $FSFormat)
+                    ) -join '' )
+
+                if ($AllowDestructive)
+                {
+                    return $false
+                }
+            } # if
+        } # if
+
+        if ($PSBoundParameters.ContainsKey('FSLabel'))
+        {
+            # Check the volume label
+            $label = $volume.FileSystemLabel
+            if ($label -ne $FSLabel)
+            {
+                # The assigned volume label is different and needs updating
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($localizedData.DriveLabelMismatch `
+                                -f $DriveLetter, $label, $FSLabel)
+                    ) -join '' )
+
+                return $false
+            } # if
+        } # if
+
+        return $true
+    } # Test-TargetResource
+
+    Export-ModuleMember -Function *-TargetResource

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
@@ -9,6 +9,6 @@ class MSFT_xDisk : OMI_BaseResource
     [Write, Description("Define volume label if required.")] String FSLabel;
     [Write, Description("Specifies the allocation unit size to use when formatting the volume.")] Uint32 AllocationUnitSize;
     [Write, Description("Specifies the file system format of the new volume."), ValueMap{"NTFS","ReFS"}, Values{"NTFS","ReFS"}] String FSFormat;
-    [Write, Description("Specifies if potentially destructive operations may occur")] Boolean AllowDestructive;
+    [Write, Description("Specifies if potentially destructive operations may occur.")] Boolean AllowDestructive;
     [Write, Description("Specifies if the disks partition schema should be removed entirely, even if data and oem partitions are present. Only possible with AllowDestructive enabled.")] Boolean ClearDisk;
 };

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
@@ -5,8 +5,10 @@ class MSFT_xDisk : OMI_BaseResource
     [Key, Description("Specifies the identifier for which disk to modify.")] String DriveLetter;
     [Required, Description("Specifies the disk identifier for the disk to modify.")] String DiskId;
     [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId"}, Values{"Number","UniqueId"}] String DiskIdType;
-    [Write, Description("Specifies the size of new volume.")] Uint64 Size;
+    [Write, Description("Specifies the size of new volume. Leave empty to use the remaining free space.")] Uint64 Size;
     [Write, Description("Define volume label if required.")] String FSLabel;
     [Write, Description("Specifies the allocation unit size to use when formatting the volume.")] Uint32 AllocationUnitSize;
     [Write, Description("Specifies the file system format of the new volume."), ValueMap{"NTFS","ReFS"}, Values{"NTFS","ReFS"}] String FSFormat;
+    [Write, Description("Specifies if potentially destructive operations may occur")] Boolean AllowDestructive;
+    [Write, Description("Specifies if the disks partition schema should be removed entirely, even if data and oem partitions are present. Only possible with AllowDestructive enabled.")] Boolean ClearDisk;
 };

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/en-us/MSFT_xDisk.strings.psd1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/en-us/MSFT_xDisk.strings.psd1
@@ -25,10 +25,14 @@
     FileSystemFormatMismatch = Volume assigned to drive {0} filesystem format '{1}' does not match expected format '{2}'.
     DriveLabelMismatch = Volume assigned to drive {0} label '{1}' does not match expected label '{2}'.
     PartitionAlreadyAssignedMessage = Partition '{1}' is already assigned as drive {0}.
-    MatchingPartitionNotFoundMessage = Disk with {0} '{1}' already contains paritions, but none match required size.
-    MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains paritions, and partition '{2}' matches required size.
+    MatchingPartitionNotFoundMessage = Disk with {0} '{1}' already contains partitions, but none match required size.
+    MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains partitions, and partition '{2}' matches required size.
     DriveNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to drive letter '{2}'.
-
+    ClearingDisk = Clearing disk with {0} '{1}' of all existing partitions and volumes.
     DiskAlreadyInitializedError = Disk with {0} '{1}' is already initialized with {2}.
     NewParitionIsReadOnlyError = New partition '{2}' on disk with {0} '{1}' did not become writable in the expected time.
+    VolumeFormatInProgress = Switch AllowDestructive is specified. Attempting to format volume on {0} with '{2}', was '{1}'
+    SizeMismatchCorrection = Switch AllowDestructive is specified. Attempting to resize partition {0} from {1} to {2}
+    FreeSpaceViolationError = Attempted to resize partition {0} from {1} to {2} while maximum allowed size was {3}
+    ResizeRefsNotPossible = Skipping resize of {0} from {1} to {2}. Resizing ReFS partitions is currently not possible.
 '@

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -212,6 +212,48 @@ try
                 $current.Size             | Should Be 100MB
             }
 
+            #region DEFAULT TESTS Resize/Reformat
+            It 'should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName      = 'localhost'
+                                DriveLetter   = $driveLetterA
+                                DiskId        = $disk.UniqueId
+                                DiskIdType    = 'UniqueId'
+                                FSLabel       = $FSLabelA
+                                Size          = 900MB
+                                FSFormat      = 'ReFS'
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_ConfigDestructive" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+
+            It 'should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            }
+            #endregion
+
+            It 'should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigDestructive"
+                }
+                $current.DiskId           | Should Be $disk.UniqueId
+                $current.DriveLetter      | Should Be $driveLetterA
+                $current.FSLabel          | Should Be $FSLabelA
+                $current.Size             | Should Be 900MB
+                $current.FSFormat         | Should Be 'ReFS'
+            }
+
             #region DEFAULT TESTS
             It 'should compile and apply the MOF without throwing' {
                 {
@@ -248,7 +290,7 @@ try
                 $current.DiskId           | Should Be $disk.UniqueId
                 $current.DriveLetter      | Should Be $driveLetterB
                 $current.FSLabel          | Should Be $FSLabelB
-                $current.Size             | Should Be 935198720
+                $current.Size             | Should Be 96337920
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions

--- a/Tests/Integration/MSFT_xDisk.config.ps1
+++ b/Tests/Integration/MSFT_xDisk.config.ps1
@@ -5,21 +5,58 @@ configuration MSFT_xDisk_Config {
     node localhost {
         if ($Node.Size)
         {
-            xDisk Integration_Test {
-                DiskId             = $Node.DiskId
-                DiskIdType         = $Node.DiskIdType
-                DriveLetter        = $Node.DriveLetter
-                FSLabel            = $Node.FSLabel
-                Size               = $Node.Size
+            xDisk Integration_Test
+            {
+                DiskId      = $Node.DiskId
+                DiskIdType  = $Node.DiskIdType
+                DriveLetter = $Node.DriveLetter
+                FSLabel     = $Node.FSLabel
+                Size        = $Node.Size
             }
         }
         else
         {
-            xDisk Integration_Test {
-                DiskId             = $Node.DiskId
-                DiskIdType         = $Node.DiskIdType
-                DriveLetter        = $Node.DriveLetter
-                FSLabel            = $Node.FSLabel
+            xDisk Integration_Test
+            {
+                DiskId      = $Node.DiskId
+                DiskIdType  = $Node.DiskIdType
+                DriveLetter = $Node.DriveLetter
+                FSLabel     = $Node.FSLabel
+            }
+        }
+    }
+}
+
+configuration MSFT_xDisk_ConfigDestructive {
+
+    Import-DscResource -ModuleName xStorage
+
+    node localhost {
+        if ($Node.Size)
+        {
+            xDisk Integration_Test
+            {
+                DiskId           = $Node.DiskId
+                DiskIdType       = $Node.DiskIdType
+                DriveLetter      = $Node.DriveLetter
+                FSLabel          = $Node.FSLabel
+                Size             = $Node.Size
+                FSFormat         = $Node.FSFormat
+                AllowDestructive = $true
+                ClearDisk        = $true
+            }
+        }
+        else
+        {
+            xDisk Integration_Test
+            {
+                DiskId           = $Node.DiskId
+                DiskIdType       = $Node.DiskIdType
+                DriveLetter      = $Node.DriveLetter
+                FSLabel          = $Node.FSLabel
+                FSFormat         = $Node.FSFormat
+                AllowDestructive = $true
+                ClearDisk        = $true
             }
         }
     }

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -319,31 +319,31 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Number)" {
+                It "Should be DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "DriveLetter should be $($script:testDriveLetter)" {
+                It "Should be DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should have size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should be FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should be AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should be FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                 }
             }
@@ -376,31 +376,31 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.UniqueId)" {
+                It "Should be DiskId $($script:mockedDisk0.UniqueId)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.UniqueId
                 }
 
-                It "DriveLetter should be $($script:testDriveLetter)" {
+                It "Should be DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should have size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should be FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should be AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should be FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                 }
             }
@@ -429,31 +429,31 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Number)" {
+                It "Should be DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "DriveLetter should be null" {
+                It "Should have an empty drive letter" {
                     $resource.DriveLetter | Should Be $null
                 }
 
-                It "Size should be null" {
+                It "Should have a zero size" {
                     $resource.Size | Should Be $null
                 }
 
-                It "FSLabel should be empty" {
+                It "Should have no FSLabel" {
                     $resource.FSLabel | Should Be ''
                 }
 
-                It "AllocationUnitSize should be null" {
+                It "Should have an AllocationUnitSize of 0" {
                     $resource.AllocationUnitSize | Should Be $null
                 }
 
-                It "FSFormat should be null" {
+                It "Should have no FSFormat" {
                     $resource.FSFormat | Should Be $null
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
                     Assert-MockCalled -CommandName Get-Disk -Exactly 1
@@ -514,7 +514,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
@@ -579,7 +579,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
@@ -643,7 +643,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
@@ -708,7 +708,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
@@ -773,7 +773,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -840,7 +840,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -901,7 +901,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -961,7 +961,7 @@ try
                     ($endTime - $startTime).TotalSeconds | Should BeGreaterThan 29
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1007,7 +1007,7 @@ try
                     } | Should Throw $errorRecord
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1050,7 +1050,7 @@ try
                     } | Should Throw $errorRecord
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1096,7 +1096,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1146,7 +1146,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1203,7 +1203,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1254,7 +1254,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1314,7 +1314,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1377,7 +1377,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1435,7 +1435,7 @@ try
                     } | Should throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1492,7 +1492,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1552,7 +1552,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1609,7 +1609,7 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
@@ -1644,7 +1644,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw when calling Test-TargetResource' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
@@ -1654,11 +1654,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -1681,7 +1681,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
@@ -1691,11 +1691,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -1718,7 +1718,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.UniqueId `
@@ -1729,11 +1729,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -1756,7 +1756,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Readonly.Number `
@@ -1766,11 +1766,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -1793,7 +1793,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Raw.Number `
@@ -1803,11 +1803,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -1840,7 +1840,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1851,11 +1851,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be true' {
+                It 'Sshould be true' {
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -1886,7 +1886,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1897,11 +1897,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -1934,7 +1934,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1944,11 +1944,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be true' {
+                It 'Should be true' {
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -1981,7 +1981,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1992,11 +1992,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -2029,7 +2029,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2039,11 +2039,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -2074,7 +2074,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2083,11 +2083,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be false' {
+                It 'Should be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -2120,7 +2120,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2133,11 +2133,11 @@ try
                     } | Should not throw
                 }
 
-                It 'result should be true' {
+                It 'Should be true' {
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call all mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -1631,6 +1631,42 @@ try
                 -CommandName Get-CimInstance `
                 -MockWith { $script:mockedCim }
 
+            Context 'Test no disk' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Get-Volume
+                Mock -CommandName Get-Partition
+                Mock -CommandName Get-CimInstance
+
+                $script:result = $null
+
+                It 'calling test Should Not Throw' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0Offline.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -AllocationUnitSize 4096 `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'result should be false' {
+                    $script:result | Should Be $false
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                }
+            }
+            
             Context 'Test disk not initialized using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
@@ -1921,6 +1957,54 @@ try
                 }
             }
 
+            Context 'Test mismatching FSFormat using Disk Number and AllowDestructive' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -MockWith { $script:mockedCim } `
+                    -Verifiable
+
+                $script:result = $null
+
+                It 'calling test Should Not Throw' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -DriveLetter $script:testDriveLetter `
+                            -FSFormat 'ReFS' `
+                            -AllowDestructive $true `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'result should be false' {
+                    $script:result | Should Be $false
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                }
+            }
+
             Context 'Test mismatching FSLabel using Disk Number' {
                 # verifiable (should be called) mocks
                 Mock `
@@ -1965,6 +2049,50 @@ try
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                }
+            }
+
+            Context 'Test mismatching DriveLetter using Disk Number' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume }
+
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -MockWith { $script:mockedCim }
+
+                $script:result = $null
+
+                It 'calling test Should Not Throw' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -DriveLetter 'Z' `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'result should be false' {
+                    $script:result | Should Be $false
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
                 }
             }
 

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xStorage'
-$script:DSCResourceName    = 'MSFT_xDisk'
+$script:DSCModuleName = 'xStorage'
+$script:DSCResourceName = 'MSFT_xDisk'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
@@ -7,9 +7,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -32,96 +32,97 @@ try
         $script:testDiskUniqueId = 'TESTDISKUNIQUEID'
 
         $script:mockedDisk0 = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'GPT'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0Mbr = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'MBR'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'MBR'
+        }
 
         $script:mockedDisk0Offline = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $true
-                IsReadOnly = $false
-                PartitionStyle = 'GPT'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $true
+            IsReadOnly     = $false
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0OfflineRaw = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $true
-                IsReadOnly = $false
-                PartitionStyle = 'Raw'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $true
+            IsReadOnly     = $false
+            PartitionStyle = 'Raw'
+        }
 
         $script:mockedDisk0Readonly = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $true
-                PartitionStyle = 'GPT'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $true
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0Raw = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'Raw'
-            }
+            Number         = 0
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'Raw'
+        }
 
-        $script:mockedCim = [pscustomobject] @{BlockSize=4096}
+        $script:mockedCim = [pscustomobject] @{BlockSize = 4096}
 
         $script:mockedPartitionSize = 1GB
 
         $script:mockedPartition = [pscustomobject] @{
-                DriveLetter = $script:testDriveLetter
-                Size = $script:mockedPartitionSize
-                PartitionNumber = 1
-                Type = 'Basic'
-            }
+            DriveLetter     = $script:testDriveLetter
+            Size            = $script:mockedPartitionSize
+            PartitionNumber = 1
+            Type            = 'Basic'
+        }
 
         $script:mockedPartitionNoDriveLetter = [pscustomobject] @{
-                DriveLetter = ''
-                Size = $script:mockedPartitionSize
-                PartitionNumber = 1
-                Type = 'Basic'
-            }
+            DriveLetter     = ''
+            Size            = $script:mockedPartitionSize
+            PartitionNumber = 1
+            Type            = 'Basic'
+        }
 
         $script:mockedVolume = [pscustomobject] @{
-                FileSystemLabel = 'myLabel'
-                FileSystem = 'NTFS'
-            }
+            FileSystemLabel = 'myLabel'
+            FileSystem      = 'NTFS'
+        }
 
         $script:mockedVolumeUnformatted = [pscustomobject] @{
-                FileSystemLabel = ''
-                FileSystem = ''
-            }
+            FileSystemLabel = ''
+            FileSystem      = ''
+        }
 
         $script:mockedVolumeNoDriveLetter = [pscustomobject] @{
-                FileSystemLabel = 'myLabel'
-                FileSystem = 'NTFS'
-            }
+            FileSystemLabel = 'myLabel'
+            FileSystem      = 'NTFS'
+        }
 
         $script:mockedVolumeReFS = [pscustomobject] @{
-                FileSystemLabel = 'myLabel'
-                FileSystem = 'ReFS'
-            }
+            FileSystemLabel = 'myLabel'
+            FileSystem      = 'ReFS'
+        }
         #endregion
 
         #region functions for mocking pipeline
         # These functions are required to be able to mock functions where
         # values are passed in via the pipeline.
-        function Set-Disk {
+        function Set-Disk
+        {
             Param
             (
                 [CmdletBinding()]
@@ -136,7 +137,8 @@ try
             )
         }
 
-        function Initialize-Disk {
+        function Initialize-Disk
+        {
             Param
             (
                 [CmdletBinding()]
@@ -148,7 +150,8 @@ try
             )
         }
 
-        function Get-Partition {
+        function Get-Partition
+        {
             Param
             (
                 [CmdletBinding()]
@@ -166,7 +169,8 @@ try
             )
         }
 
-        function New-Partition {
+        function New-Partition
+        {
             Param
             (
                 [CmdletBinding()]
@@ -184,7 +188,8 @@ try
             )
         }
 
-        function Set-Partition {
+        function Set-Partition
+        {
             Param
             (
                 [CmdletBinding()]
@@ -199,7 +204,8 @@ try
             )
         }
 
-        function Get-Volume {
+        function Get-Volume
+        {
             Param
             (
                 [CmdletBinding()]
@@ -211,7 +217,8 @@ try
             )
         }
 
-        function Set-Volume {
+        function Set-Volume
+        {
             Param
             (
                 [CmdletBinding()]
@@ -223,7 +230,8 @@ try
             )
         }
 
-        function Format-Volume {
+        function Format-Volume
+        {
             Param
             (
                 [CmdletBinding()]
@@ -243,7 +251,33 @@ try
                 $NewFileSystemLabel,
 
                 [Uint32]
-                $AllocationUnitSize
+                $AllocationUnitSize,
+
+                [Switch]
+                $Force
+            )
+        }
+
+        function Get-PartitionSupportedSize
+        {
+            param
+            (
+                [Parameter(ValueFromPipeline = $true)]
+                [String]
+                $DriveLetter
+            )
+        }
+
+        function Resize-Partition
+        {
+            param
+            (
+                [Parameter(ValueFromPipeline = $true)]
+                [String]
+                $DriveLetter,
+
+                [UInt64]
+                $Size
             )
         }
         #endregion
@@ -442,8 +476,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -481,8 +515,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -506,8 +540,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -546,8 +580,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -571,8 +605,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -610,8 +644,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -639,8 +673,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -675,8 +709,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -700,8 +734,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -740,8 +774,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -761,8 +795,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq $script:testDriveLetter
-                    } `
+                    $DriveLetter -eq $script:testDriveLetter
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -801,8 +835,8 @@ try
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName New-Partition -Times 1 `
                         -ParameterFilter {
-                            $DriveLetter -eq $script:testDriveLetter
-                        }
+                        $DriveLetter -eq $script:testDriveLetter
+                    }
                     Assert-MockCalled -CommandName Format-Volume -Times 1
                     Assert-MockCalled -CommandName Set-Partition -Times 1
                 }
@@ -826,7 +860,7 @@ try
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.DiskAlreadyInitializedError -f `
-                        'Number',$script:mockedDisk0Mbr.Number,$script:mockedDisk0Mbr.PartitionStyle)
+                        'Number', $script:mockedDisk0Mbr.Number, $script:mockedDisk0Mbr.PartitionStyle)
 
                 It 'Should throw DiskAlreadyInitializedError' {
                     {
@@ -868,7 +902,7 @@ try
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.DiskAlreadyInitializedError -f `
-                        'UniqueId',$script:mockedDisk0Mbr.UniqueId,$script:mockedDisk0Mbr.PartitionStyle)
+                        'UniqueId', $script:mockedDisk0Mbr.UniqueId, $script:mockedDisk0Mbr.PartitionStyle)
 
                 It 'Should throw DiskAlreadyInitializedError' {
                     {
@@ -1009,8 +1043,8 @@ try
                 Mock `
                     -CommandName New-Partition `
                     -ParameterFilter {
-                        $DriveLetter -eq 'H'
-                    } `
+                    $DriveLetter -eq 'H'
+                } `
                     -MockWith { $script:mockedPartitionNoDriveLetter } `
                     -Verifiable
 
@@ -1080,6 +1114,187 @@ try
                             -DiskId $script:mockedDisk0.Number `
                             -Driveletter $script:testDriveLetter `
                             -FSLabel 'NewLabel' `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                }
+            }
+
+            Context 'AllowDestructive: Online GPT disk with matching partition/volume but wrong size' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Volume `
+                    -Verifiable
+                Mock `
+                    -CommandName Resize-Partition `
+                    -Verifiable
+                Mock `
+                    -CommandName Get-PartitionSupportedSize `
+                    -MockWith {
+                    return @{
+                        SizeMin = 0
+                        SizeMax = [int64]::MaxValue
+                    }
+                } `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Set-Disk
+                Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
+                Mock -CommandName Format-Volume
+                Mock -CommandName Set-Partition
+
+                It 'Should not throw' {
+                    {
+                        Set-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -Driveletter $script:testDriveLetter `
+                            -Size ($script:mockedPartitionSize + 1024) `
+                            -AllowDestructive $true `
+                            -FSLabel 'NewLabel' `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                }
+            }
+
+            Context 'AllowDestructive: Online GPT disk with matching partition/volume but wrong format' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Volume `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Format-Volume `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Set-Disk
+                Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition                
+                Mock -CommandName Set-Partition
+
+                It 'Should not throw' {
+                    {
+                        Set-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -Driveletter $script:testDriveLetter `
+                            -Size $script:mockedPartitionSize `
+                            -FSFormat 'ReFS' `
+                            -FSLabel 'NewLabel' `
+                            -AllowDestructive $true `
+                            -Verbose
+                    } | Should not throw
+                }
+
+                It 'the correct mocks were called' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                }
+            }
+
+            Context 'AllowDestructive: Online GPT disk containing arbitrary partitions' {
+                # verifiable (should be called) mocks
+                Mock `
+                    -CommandName Get-Disk `
+                    -MockWith { $script:mockedDisk0 } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Partition `
+                    -MockWith { $script:mockedPartition } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-Volume `
+                    -MockWith { $script:mockedVolume } `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Set-Volume `
+                    -Verifiable
+                Mock `
+                    -CommandName Clear-Disk `
+                    -Verifiable
+
+                # mocks that should not be called
+                Mock -CommandName Set-Disk
+                Mock -CommandName Initialize-Disk
+                Mock -CommandName New-Partition
+                Mock -CommandName Format-Volume
+                Mock -CommandName Set-Partition
+
+                It 'Should not throw' {
+                    {
+                        Set-TargetResource `
+                            -DiskId $script:mockedDisk0.Number `
+                            -Driveletter $script:testDriveLetter `
+                            -Size $script:mockedPartitionSize `
+                            -FSLabel 'NewLabel' `
+                            -AllowDestructive $true `
+                            -ClearDisk $true `
                             -Verbose
                     } | Should not throw
                 }


### PR DESCRIPTION
New parameters AllowDestructive and ClearDisk added. AllowDestructive indicates that potentially destructive changes (partition size change, file system format) are allowed to take place. AllowDestructive together with ClearDisk furthermore indicates that the target disk should be cleared of all data and OEM partitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/90)
<!-- Reviewable:end -->
