### PR TITLE
Prevent ResourceHelper and Common cmdlets from being exported - Fixes #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
+
 ## 3.0.0.0
 
 - Converted AppVeyor build process to use AppVeyor.psm1.

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -5,12 +5,12 @@ param ()
 
 $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the Networking Common Modules
+# Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.Common' `
                                                      -ChildPath 'StorageDsc.Common.psm1'))
 
-# Import the Networking Resource Helper Module
+# Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
                                                      -ChildPath 'StorageDsc.ResourceHelper.psm1'))

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -3,10 +3,17 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param ()
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xStorage.psd1')
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+                                                     -ChildPath 'StorageDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -5,12 +5,12 @@ param ()
 
 $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the Networking Common Modules
+# Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.Common' `
                                                      -ChildPath 'StorageDsc.Common.psm1'))
 
-# Import the Networking Resource Helper Module
+# Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
                                                      -ChildPath 'StorageDsc.ResourceHelper.psm1'))

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -3,10 +3,17 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param ()
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xStorage.psd1')
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+                                                     -ChildPath 'StorageDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xStorage/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -7,12 +7,12 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the Networking Common Modules
+# Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.Common' `
                                                      -ChildPath 'StorageDsc.Common.psm1'))
 
-# Import the Networking Resource Helper Module
+# Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
                                                      -ChildPath 'StorageDsc.ResourceHelper.psm1'))

--- a/Modules/xStorage/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xMountImage/MSFT_xMountImage.psm1
@@ -3,10 +3,19 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param ()
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xStorage.psd1')
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+                                                     -ChildPath 'StorageDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -5,12 +5,12 @@ param ()
 
 $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the Networking Common Modules
+# Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.Common' `
                                                      -ChildPath 'StorageDsc.Common.psm1'))
 
-# Import the Networking Resource Helper Module
+# Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
                                                      -ChildPath 'StorageDsc.ResourceHelper.psm1'))

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -3,10 +3,17 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param ()
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xStorage.psd1')
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+                                                     -ChildPath 'StorageDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
@@ -5,12 +5,12 @@ param ()
 
 $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the Networking Common Modules
+# Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.Common' `
                                                      -ChildPath 'StorageDsc.Common.psm1'))
 
-# Import the Networking Resource Helper Module
+# Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
                                                      -ChildPath 'StorageDsc.ResourceHelper.psm1'))

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForVolume/MSFT_xWaitForVolume.psm1
@@ -3,10 +3,17 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param ()
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xStorage.psd1')
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+                                                     -ChildPath 'StorageDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xStorage/xStorage.psd1
+++ b/Modules/xStorage/xStorage.psd1
@@ -61,7 +61,7 @@ PowerShellVersion = '4.0'
 # FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-NestedModules = @('Modules\StorageDsc.Common\StorageDsc.Common.psm1','Modules\StorageDsc.ResourceHelper\StorageDsc.ResourceHelper.psm1')
+# NestedModules = @()
 
 # Functions to export from this module
 FunctionsToExport = '*'

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -34,7 +34,7 @@ try
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
                     Install-Module -Name $moduleToTest -ErrorAction Stop
-                } | Should not throw
+                } | Should Not Throw
             }
         }
     }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,0 +1,47 @@
+$script:DSCModuleName      = 'xStorage'
+<#
+    These integration tests ensure that exported cmdlets names do not conflict
+    with any other names that are exposed by other common resource kit modules.
+#>
+$script:ModulesToTest = @( 'xNetworking','xComputerManagement','xDFS' )
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "$($script:DSCModuleName).psd1") -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName 'All' `
+    -TestType Integration
+
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    Describe "$($script:DSCModuleName)_CommonModuleConflict" {
+        
+        foreach ($moduleToTest in $script:ModulesToTest)
+        {
+            It "Should be able to install DSC Resource module '$moduleToTest'" {
+                {
+                    Install-Module -Name $moduleToTest -ErrorAction Stop
+                } | Should not throw
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}


### PR DESCRIPTION
This resolves a high priority issue with newer versions of xNetworking, xCertificate, xStorage and xDFS conflicting with each other because the ResourceHelper cmdlets are being exported due to the way each resource imported them (using the PSD1 nested modules array).

This should be resolved in xNetworking, xStorage and xDFS as well to ensure no other conflicts.

This also contains a new integration test that will check for any further conflicts between resource modules. At some point it might be possible to move this test into the DSCResource.Tests common tests to provide more comprehensive conflict prevention. However, because the conflicts will potentially be between three different modules the number of modules compared will have to go in over time.

This fixes #93

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/94)
<!-- Reviewable:end -->
