### PR TITLE
Fix Error Message Reported in xDisk & xDiskAccessPath if new partition does not become writable - Fixes #97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- xDisk:
+  - Fix error message when new partition does not become writable before timeout.
+  - Removed unneeded timeout initialization code.
+- xDiskAccessPath:
+  - Fix error message when new partition does not become writable before timeout.
+  - Removed unneeded timeout initialization code.
+
 ## 3.1.0.0
 
 - Added integration test to test for conflicts with other common resource kit modules.

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -352,7 +352,6 @@ function Set-TargetResource
                 After creating the partition it can take a few seconds for it to become writeable
                 Wait for up to 30 seconds for the parition to become writeable
             #>
-            $start = Get-Date
             $timeout = (Get-Date) + (New-Timespan -Second 30)
             while ($partition.IsReadOnly -and (Get-Date) -lt $timeout)
             {
@@ -373,7 +372,7 @@ function Set-TargetResource
         {
             # The partition is still readonly - throw an exception
             New-InvalidOperationException `
-                -Message ($localizedData.ParitionIsReadOnlyError -f `
+                -Message ($localizedData.NewParitionIsReadOnlyError -f `
                     $DiskIdType,$DiskId,$partition.PartitionNumber)
         } # if
 

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -349,7 +349,6 @@ function Set-TargetResource
                 After creating the partition it can take a few seconds for it to become writeable
                 Wait for up to 30 seconds for the partition to become writeable
             #>
-            $start = Get-Date
             $timeout = (Get-Date) + (New-Timespan -Second 30)
             while ($partition.IsReadOnly -and (Get-Date) -lt $timeout)
             {
@@ -367,7 +366,7 @@ function Set-TargetResource
         {
             # The partition is still readonly - throw an exception
             New-InvalidOperationException `
-                -Message ($localizedData.ParitionIsReadOnlyError -f `
+                -Message ($localizedData.NewParitionIsReadOnlyError -f `
                     $DiskIdType,$DiskId,$partition.PartitionNumber)
         } # if
 


### PR DESCRIPTION
This is a minor fix to the error messages returned when a newly created partition does not become writable within 30 seconds. This was caused by the wrong Localization string label being specified.

This also removed two lines of code that were not actually required in the timeout.

- xDisk:
 - Fix error message when new partition does not become writable before timeout.
  - Removed unneeded timeout initialization code.
- xDiskAccessPath:
  - Fix error message when new partition does not become writable before timeout.
  - Removed unneeded timeout initialization code.

@Johlju - if you get a moment, would you mind reviewing? We really need some more reviewers so you can get a well deserved rest! :grin:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/98)
<!-- Reviewable:end -->
