### PR TITLE
Fix bug in xDiskAccessPath and xMountImage and enabled Integration Tests - Fixes #102, #105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix error when used on Windows Server 2012 R2 - See [Issue 102](https://github.com/PowerShell/xStorage/issues/102).
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
+- Removed requirement on Hyper-V PowerShell module to execute integration tests.
 
 ## 3.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@
 - xDiskAccessPath:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
+  - Fix error when used on Windows Server 2012 R2 - See [Issue 102](https://github.com/PowerShell/xStorage/issues/102).
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
-- Force the use of Windows Server 2012 R2 for AppVeyor testing to ensure
-  compatibility testing.
 
 ## 3.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Removed unneeded timeout initialization code.
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
+- Force the use of Windows Server 2012 R2 for AppVeyor testing to ensure
+  compatibility testing.
 
 ## 3.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
 - Removed requirement on Hyper-V PowerShell module to execute integration tests.
+- xMountImage:
+  - Fix error when mounting VHD on Windows Server 2012 R2 - See [Issue 105](https://github.com/PowerShell/xStorage/issues/105)
 
 ## 3.1.0.0
 

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -456,8 +456,14 @@ function Set-TargetResource
     # Assign the access path if it isn't assigned
     if ($assignAccessPath)
     {
-        $null = $disk | Add-PartitionAccessPath `
+        <#
+            Add the partition access path, but do not pipe $disk to
+            Add-PartitionAccessPath because it is not supported in
+            Windows Server 2012 R2
+        #>
+        $null = Add-PartitionAccessPath `
             -AccessPath $AccessPath `
+            -DiskNumber $disk.Number `
             -PartitionNumber $partition.PartitionNumber
 
         Write-Verbose -Message ( @(

--- a/Modules/xStorage/DSCResources/MSFT_xMountImage/en-us/MSFT_xMountImage.strings.psd1
+++ b/Modules/xStorage/DSCResources/MSFT_xMountImage/en-us/MSFT_xMountImage.strings.psd1
@@ -18,5 +18,5 @@ ConvertFrom-StringData @'
     DiskImageFileNotFoundError = The image file '{0}' could not be found.
 
     MountingImageMessage = The image file '{0}' is being mounted as drive '{1}'.
-    ChangingISODriveLetterMessage = ISO image file '{0}' mounted as drive '{1}' but is being changed to '{2}'.
+    ChangingImageDriveLetterMessage = The image file '{0}' mounted as drive '{1}' will be changed to '{2}'.
 '@

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -22,12 +22,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    # Ensure that the tests can be performed on this computer
-    if (-not (Test-HyperVInstalled))
-    {
-        Return
-    }
-
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
@@ -35,11 +29,11 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Drive Letters' {
             BeforeAll {
-                # Create a VHDx and attach it to the computer
+                # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
-                    -ChildPath 'TestDisk.vhdx'
-                New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
-                Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
@@ -144,7 +138,7 @@ try
             }
 
             AfterAll {
-                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHDx
+                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
                 Remove-Item -Path $VHDPath -Force
             }
         }
@@ -155,11 +149,11 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk using Unique Id with two volumes and assign Drive Letters' {
             BeforeAll {
-                # Create a VHDx and attach it to the computer
+                # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
-                    -ChildPath 'TestDisk.vhdx'
-                New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
-                Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
@@ -265,8 +259,8 @@ try
             }
 
             AfterAll {
-                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHDx
-                Remove-Item -Path $VHDPath -Force
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
             }
         }
     }

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -34,9 +34,8 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                $disk = Get-Disk | Where-Object -FilterScript {
-                    $_.Location -eq $VHDPath
-                }
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
                 $FSLabelA = 'TestDiskA'
                 $FSLabelB = 'TestDiskB'
 
@@ -154,9 +153,8 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                $disk = Get-Disk | Where-Object -FilterScript {
-                    $_.Location -eq $VHDPath
-                }
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
                 $FSLabelA = 'TestDiskA'
                 $FSLabelB = 'TestDiskB'
 

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -128,13 +128,18 @@ try
                 ($disk | Get-Partition).Count | Should Be 3
             }
 
-            Write-Verbose -Verbose -Message (Get-PSDrive | FL * | Out-String)
+            <#
+                Get a list of all drives mounted - this works better on Windows Server 2012 R2 than
+                trying to get the drive mounted by name.
+            #>
+            $drives = Get-PSDrive
+
             It "should have attached drive $driveLetterA" {
-                Get-PSDrive -Name $driveLetterA -ErrorAction SilentlyContinue | Should Not BeNullOrEmpty
+                $drives | Where-Object -Property Name -eq $driveLetterA | Should Not BeNullOrEmpty
             }
 
             It "should have attached drive $driveLetterB" {
-                Get-PSDrive -Name $driveLetterB -ErrorAction SilentlyContinue | Should Not BeNullOrEmpty
+                $drives | Where-Object -Property Name -eq $driveLetterB | Should Not BeNullOrEmpty
             }
 
             AfterAll {

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -46,7 +46,7 @@ try
             }
 
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -70,12 +70,12 @@ try
                 } | Should Not Throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
             }
             #endregion
 
-            It 'should have set the resource and all the parameters should match' {
+            It 'Should have set the resource and all the parameters should match' {
                 $current = Get-DscConfiguration | Where-Object {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
@@ -85,7 +85,7 @@ try
                 $current.Size             | Should Be 100MB
             }
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -108,12 +108,12 @@ try
                 } | Should Not Throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
             }
             #endregion
 
-            It 'should have set the resource and all the parameters should match' {
+            It 'Should have set the resource and all the parameters should match' {
                 $current = Get-DscConfiguration | Where-Object {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
@@ -124,10 +124,11 @@ try
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
-            It 'should have 3 partitions on disk' {
+            It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should Be 3
             }
 
+            Write-Verbose -Verbose -Message (Get-PSDrive | FL * | Out-String)
             It "should have attached drive $driveLetterA" {
                 Get-PSDrive -Name $driveLetterA -ErrorAction SilentlyContinue | Should Not BeNullOrEmpty
             }
@@ -165,7 +166,7 @@ try
             }
 
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -189,12 +190,12 @@ try
                 } | Should Not Throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
             }
             #endregion
 
-            It 'should have set the resource and all the parameters should match' {
+            It 'Should have set the resource and all the parameters should match' {
                 $current = Get-DscConfiguration | Where-Object {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
@@ -205,7 +206,7 @@ try
             }
 
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -228,12 +229,12 @@ try
                 } | Should Not Throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
             }
             #endregion
 
-            It 'should have set the resource and all the parameters should match' {
+            It 'Should have set the resource and all the parameters should match' {
                 $current = Get-DscConfiguration | Where-Object {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
@@ -244,7 +245,7 @@ try
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
-            It 'should have 3 partitions on disk' {
+            It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should Be 3
             }
 

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -32,7 +32,7 @@ try
                 # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
                     -ChildPath 'TestDisk.vhd'
-                $null = New-VDisk -Path $VHDPath -SizeInMB 1024
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -34,7 +34,6 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-
                 $diskImage = Get-DiskImage -ImagePath $VHDPath
                 $disk = Get-Disk -Number $diskImage.Number
                 $FSLabelA = 'TestDiskA'
@@ -215,9 +214,8 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                $disk = Get-Disk | Where-Object -FilterScript {
-                    $_.Location -eq $VHDPath
-                }
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
                 $FSLabelA = 'TestDiskA'
                 $FSLabelB = 'TestDiskB'
 

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -34,11 +34,9 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                Write-Verbose -Verbose -Message (Get-Disk | FL * | Out-String )
-                $disk = Get-Disk | Where-Object -FilterScript {
-                    $_.Location -eq $VHDPath
-                }
-                Write-Verbose -Verbose -Message ($disk | Out-String)
+
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
                 $FSLabelA = 'TestDiskA'
                 $FSLabelB = 'TestDiskB'
 

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -54,7 +54,7 @@ try
             }
 
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -78,7 +78,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -100,11 +100,12 @@ try
                 -NoNewline
 
             # This test will ensure the disk can be remounted if the access path is removed.
-            $disk | Remove-PartitionAccessPath `
+            Remove-PartitionAccessPath `
+                -DiskNumber $disk.Number `
                 -PartitionNumber 2 `
                 -AccessPath $accessPathA
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -128,7 +129,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -147,7 +148,7 @@ try
                 Get-Content -Path $testFilePath -Raw | Should Be 'Test'
             }
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -170,7 +171,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -185,17 +186,19 @@ try
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
-            It 'should have 3 partitions on disk' {
+            It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should Be 3
             }
             #endregion
 
             AfterAll {
                 # Clean up
-                $disk | Remove-PartitionAccessPath `
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
                     -PartitionNumber 2 `
                     -AccessPath $accessPathA
-                $disk | Remove-PartitionAccessPath `
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
                     -PartitionNumber 3 `
                     -AccessPath $accessPathB
                 $null = Remove-Item -Path $accessPathA -Force
@@ -234,7 +237,7 @@ try
             }
 
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -258,7 +261,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -280,11 +283,12 @@ try
                 -NoNewline
 
             # This test will ensure the disk can be remounted if the access path is removed.
-            $disk | Remove-PartitionAccessPath `
+            Remove-PartitionAccessPath `
+                -DiskNumber $disk.Number `
                 -PartitionNumber 2 `
                 -AccessPath $accessPathA
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -308,7 +312,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -327,7 +331,7 @@ try
                 Get-Content -Path $testFilePath -Raw | Should Be 'Test'
             }
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -350,7 +354,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
 
@@ -365,17 +369,19 @@ try
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
-            It 'should have 3 partitions on disk' {
+            It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should Be 3
             }
             #endregion
 
             AfterAll {
                 # Clean up
-                $disk | Remove-PartitionAccessPath `
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
                     -PartitionNumber 2 `
                     -AccessPath $accessPathA
-                $disk | Remove-PartitionAccessPath `
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
                     -PartitionNumber 3 `
                     -AccessPath $accessPathB
                 $null = Remove-Item -Path $accessPathA -Force

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -34,7 +34,7 @@ try
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                Write-Verbose -Verbose -Message (Get-Disk | Out-String)
+                Write-Verbose -Verbose -Message (Get-Disk | FL * | Out-String )
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -22,12 +22,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    # Ensure that the tests can be performed on this computer
-    if (-not (Test-HyperVInstalled))
-    {
-        Return
-    }
-
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
@@ -35,11 +29,11 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Access Paths' {
             BeforeAll {
-                # Create a VHDx and attach it to the computer
+                # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
-                    -ChildPath 'TestDisk.vhdx'
-                New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
-                Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
@@ -50,12 +44,13 @@ try
                 $accessPathA = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountA'
                 if (-not (Test-Path -Path $accessPathA))
                 {
-                    New-Item -Path $accessPathA -ItemType Directory
+                    $null = New-Item -Path $accessPathA -ItemType Directory
                 } # if
+
                 $accessPathB = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountB'
                 if (-not (Test-Path -Path $accessPathB))
                 {
-                    New-Item -Path $accessPathB -ItemType Directory
+                    $null = New-Item -Path $accessPathB -ItemType Directory
                 } # if
             }
 
@@ -204,10 +199,10 @@ try
                 $disk | Remove-PartitionAccessPath `
                     -PartitionNumber 3 `
                     -AccessPath $accessPathB
-                Remove-Item -Path $accessPathA -Force
-                Remove-Item -Path $accessPathB -Force
-                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHDx
-                Remove-Item -Path $VHDPath -Force
+                $null = Remove-Item -Path $accessPathA -Force
+                $null = Remove-Item -Path $accessPathB -Force
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
             }
         }
         #endregion
@@ -215,11 +210,11 @@ try
         #region Integration Tests for Disk Unique Id
         Context 'Partition and format newly provisioned disk using Disk Unique Id with two volumes and assign Access Paths' {
             BeforeAll {
-                # Create a VHDx and attach it to the computer
+                # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
-                    -ChildPath 'TestDisk.vhdx'
-                New-VHD -Path $VHDPath -SizeBytes 1GB -Dynamic
-                Mount-DiskImage -ImagePath $VHDPath -StorageType VHDX -NoDriveLetter
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
@@ -230,12 +225,13 @@ try
                 $accessPathA = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountA'
                 if (-not (Test-Path -Path $accessPathA))
                 {
-                    New-Item -Path $accessPathA -ItemType Directory
+                    $null = New-Item -Path $accessPathA -ItemType Directory
                 } # if
+
                 $accessPathB = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountB'
                 if (-not (Test-Path -Path $accessPathB))
                 {
-                    New-Item -Path $accessPathB -ItemType Directory
+                    $null = New-Item -Path $accessPathB -ItemType Directory
                 } # if
             }
 
@@ -384,10 +380,10 @@ try
                 $disk | Remove-PartitionAccessPath `
                     -PartitionNumber 3 `
                     -AccessPath $accessPathB
-                Remove-Item -Path $accessPathA -Force
-                Remove-Item -Path $accessPathB -Force
-                Dismount-DiskImage -ImagePath $VHDPath -StorageType VHDx
-                Remove-Item -Path $VHDPath -Force
+                $null = Remove-Item -Path $accessPathA -Force
+                $null = Remove-Item -Path $accessPathB -Force
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
             }
         }
     }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -29,6 +29,7 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Access Paths' {
             BeforeAll {
+                Write-Verbose -Verbose -Message "In BeforeAll"
                 # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
                     -ChildPath 'TestDisk.vhd'
@@ -54,6 +55,8 @@ try
                     $null = New-Item -Path $accessPathB -ItemType Directory
                 } # if
             }
+
+            Write-Verbose -Verbose -Message "Begin tests"
 
             #region DEFAULT TESTS
             It 'should compile and apply the MOF without throwing' {

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -37,6 +37,7 @@ try
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
+                Write-Verbose -Verbose -Message ($disk | Out-String)
                 $FSLabelA = 'TestDiskA'
                 $FSLabelB = 'TestDiskB'
 

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -29,12 +29,12 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Access Paths' {
             BeforeAll {
-                Write-Verbose -Verbose -Message "In BeforeAll"
                 # Create a VHD and attach it to the computer
                 $VHDPath = Join-Path -Path $TestDrive `
                     -ChildPath 'TestDisk.vhd'
                 $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
                 $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
+                Write-Verbose -Verbose -Message (Get-Disk | Out-String)
                 $disk = Get-Disk | Where-Object -FilterScript {
                     $_.Location -eq $VHDPath
                 }
@@ -55,8 +55,6 @@ try
                     $null = New-Item -Path $accessPathB -ItemType Directory
                 } # if
             }
-
-            Write-Verbose -Verbose -Message "Begin tests"
 
             #region DEFAULT TESTS
             It 'should compile and apply the MOF without throwing' {

--- a/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
@@ -60,7 +60,7 @@ try
     Describe "$($script:DSCResourceName)_MountISO_Integration" {
         Context 'Mount an ISO and assign a Drive Letter' {
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Mount_Config" `
                         -OutputPath $TestDrive `
@@ -70,7 +70,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion
@@ -95,7 +95,7 @@ try
     Describe "$($script:DSCResourceName)_DismountISO_Integration" {
         Context 'Dismount a previously mounted ISO' {
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Dismount_Config" `
                         -OutputPath $TestDrive `
@@ -105,7 +105,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -36,7 +36,7 @@ try
     $disk = Get-Disk -Number $diskImage.Number
     $null = $disk | Initialize-Disk -PartitionStyle GPT
     $partition = $disk | New-Partition -UseMaximumSize
-    $null = $partition | Get-Volume | Format-Volume -FileSystem NTFS
+    $null = $partition | Get-Volume | Format-Volume -FileSystem NTFS -Confirm:$false
     $null = Dismount-Diskimage -ImagePath $VHDPath
 
     # Create a config data object to pass to the DSC Configs

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -32,7 +32,8 @@ try
         -ChildPath 'TestDisk.vhd'
     $null = New-VDisk -Path $VHDPath -SizeInMB 1024
     $null = Mount-DiskImage -ImagePath $VHDPath
-    $disk = Get-Disk | Where-Object -Property Location -eq -Value $VHDPath
+    $diskImage = Get-DiskImage -ImagePath $VHDPath
+    $disk = Get-Disk -Number $diskImage.Number
     $null = $disk | Initialize-Disk -PartitionStyle GPT
     $partition = $disk | New-Partition -UseMaximumSize
     $null = $partition | Get-Volume | Format-Volume -FileSystem NTFS

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -57,7 +57,7 @@ try
     Describe "$($script:DSCResourceName)_MountVHD_Integration" {
         Context 'Mount an VHDX and assign a Drive Letter' {
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Mount_Config" `
                         -OutputPath $TestDrive `
@@ -67,7 +67,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion
@@ -92,7 +92,7 @@ try
     Describe "$($script:DSCResourceName)_DismountVHD_Integration" {
         Context 'Dismount a previously mounted ISO' {
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Dismount_Config" `
                         -OutputPath $TestDrive `
@@ -102,7 +102,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion

--- a/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
@@ -33,7 +33,7 @@ try
         Context 'Wait for a Disk using Disk Number' {
             #region DEFAULT TESTS
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -55,7 +55,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion
@@ -73,7 +73,7 @@ try
         Context 'Wait for a Disk using Disk Unique Id' {
             #region DEFAULT TESTS
 
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     # This is to pass to the Config
                     $configData = @{
@@ -95,7 +95,7 @@ try
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion

--- a/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
@@ -29,14 +29,14 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Wait for a Volume' {
             #region DEFAULT TESTS
-            It 'should compile and apply the MOF without throwing' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                 } | Should not throw
             }
 
-            It 'should be able to call Get-DscConfiguration without throwing' {
+            It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
             #endregion

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,5 +1,4 @@
 $script:DSCModuleName      = 'xStorage'
-return
 <#
     These integration tests ensure that exported cmdlets names do not conflict
     with any other names that are exposed by other common resource kit modules.

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,4 +1,5 @@
 $script:DSCModuleName      = 'xStorage'
+return
 <#
     These integration tests ensure that exported cmdlets names do not conflict
     with any other names that are exposed by other common resource kit modules.
@@ -28,7 +29,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     Describe "$($script:DSCModuleName)_CommonModuleConflict" {
-        
+
         foreach ($moduleToTest in $script:ModulesToTest)
         {
             It "Should be able to install DSC Resource module '$moduleToTest'" {

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -102,7 +102,10 @@ function New-VDisk
 
     $tempScriptPath = Join-Path -Path $ENV:Temp -ChildPath 'DiskPartVdiskScript.txt'
     Write-Verbose -Message ('Creating DISKPART script {0}' -f $tempScriptPath)
-    Set-Content -Path $tempScriptPath -Value "create vdisk file=`"$Path`" type=expandable maximum=$SizeInMB"
+    Set-Content `
+        -Path $tempScriptPath `
+        -Value "create vdisk FILE=`"$Path`" TYPE=EXPANDABLE MAXIMUM=$SizeInMB" `
+        -Encoding Ascii
     $result = & DISKPART @('/s',$tempScriptPath)
     Write-Verbose -Message ($Result | Out-String)
     $null = Remove-Item -Path $tempScriptPath -Force

--- a/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
@@ -217,12 +217,11 @@ try
         function Add-PartitionAccessPath {
             Param
             (
-                [CmdletBinding()]
-                [Parameter(ValueFromPipeline = $true)]
-                $Disk,
-
                 [String]
                 $AccessPath,
+
+                [Uint32]
+                $DiskNumber,
 
                 [Uint32]
                 $PartitionNumber

--- a/Tests/Unit/MSFT_xMountImage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMountImage.Tests.ps1
@@ -1027,7 +1027,7 @@ try
 
                 Mock `
                     -CommandName Get-DiskImage `
-                    -MockWith { $script:mockedDiskImageVHDX } `
+                    -MockWith { $script:mockedDiskImageAttachedVHDX } `
                     -Verifiable
 
                 Mock `
@@ -1070,7 +1070,7 @@ try
                 }
             }
 
-            Context 'ISO is specified and gets mounted to the wrong Drive Letter' {
+            Context 'VHDX is specified and gets mounted to the wrong Drive Letter' {
                 # Verifiable (should be called) mocks
                 Mock `
                     -CommandName Mount-DiskImage `
@@ -1078,7 +1078,7 @@ try
 
                 Mock `
                     -CommandName Get-DiskImage `
-                    -MockWith { $script:mockedDiskImageVHDX } `
+                    -MockWith { $script:mockedDiskImageAttachedVHDX } `
                     -Verifiable
 
                 Mock `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@
 #      environment configuration  #
 #---------------------------------#
 version: 2.9.{build}.0
+# Force use Windows Server 2012 R2
+image: Visual Studio 2015
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@
 #      environment configuration  #
 #---------------------------------#
 version: 2.9.{build}.0
-# Force use Windows Server 2012 R2
-image: Visual Studio 2015
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
 


### PR DESCRIPTION
This PR primarily fixes #102.

However during investigation of #102, I found a way to enable the integration tests to run in AppVeyor by using DISKPART to create a new VHD. I decided to enable these to ensure that this module is being effectively tested on Windows Server 2012 R2.

This highlighted issue #105 as the integration tests failed on the AppVeyor build agent (but passed on Windows 10 and Windows Server 2016). I identified the cause of the problem and fixed it as well so that I could commit this fix.

The PR changes are as per:
- xDiskAccessPath:
  - Fix error when used on Windows Server 2012 R2 - See [Issue 102](https://github.com/PowerShell/xStorage/issues/102).
- Removed requirement on Hyper-V PowerShell module to execute integration tests.
- xMountImage:
  - Fix error when mounting VHD on Windows Server 2012 R2 - See [Issue 105](https://github.com/PowerShell/xStorage/issues/105)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/106)
<!-- Reviewable:end -->
