### PR TITLE
Add support for DiskIdType Guid in xDisk, xDiskAccessPath and xWaitForDisk - Fixes #104

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD029": {
+        "style": "ordered"
+    },
+    "MD013": true,
+    "MD024": true,
+    "MD034": true,
+    "no-hard-tabs": true
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,7 +3,7 @@
     "MD029": {
         "style": "ordered"
     },
-    "MD013": true,
+    "MD013": false,
     "MD024": true,
     "MD034": true,
     "no-hard-tabs": true

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,9 @@
 {
     "default": true,
     "MD029": {
-        "style": "ordered"
+        "style": "one"
     },
-    "MD013": false,
+    "MD013": true,
     "MD024": true,
     "MD034": true,
     "no-hard-tabs": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
   - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+  - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
+  - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
@@ -18,6 +20,7 @@
   - Fix error when mounting VHD on Windows Server 2012 R2 - See [Issue 105](https://github.com/PowerShell/xStorage/issues/105)
 - xWaitForDisk:
   - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+- Added .markdownlint.json file to configure markdown rules to validate.
 
 ## 3.1.0.0
 
@@ -49,8 +52,6 @@
   - Fixed style violations in xDisk.
   - Fixed issue when creating multiple partitions on a single disk with no size
     specified - See [Issue 86](https://github.com/PowerShell/xStorage/issues/86).
-  - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
-  - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
   - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to
     enable it to contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 - Added .markdownlint.json file to configure markdown rules to validate.
 - Clean up Badge area in README.MD - See [Issue 110](https://github.com/PowerShell/xStorage/issues/110)
+- Disabled MD013 rule checking to enable badge table.
 
 ## 3.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.1.0.0
+
 - Added integration test to test for conflicts with other common resource kit modules.
 - Prevented ResourceHelper and Common module cmdlets from being exported to resolve
   conflicts with other resource modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@
 - xDisk:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 - xDiskAccessPath:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
   - Fix error when used on Windows Server 2012 R2 - See [Issue 102](https://github.com/PowerShell/xStorage/issues/102).
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
 - Removed requirement on Hyper-V PowerShell module to execute integration tests.
 - xMountImage:
   - Fix error when mounting VHD on Windows Server 2012 R2 - See [Issue 105](https://github.com/PowerShell/xStorage/issues/105)
+- xWaitForDisk:
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 
 ## 3.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,30 @@
 
 ## Unreleased
 
+- xDisk:
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+  - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
+  - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
+- xDiskAccessPath:
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+- xWaitForDisk:
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+- Added .markdownlint.json file to configure markdown rules to validate.
+
 ## 3.2.0.0
 
 - xDisk:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
-  - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
-  - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
   - Fix error message when new partition does not become writable before timeout.
   - Removed unneeded timeout initialization code.
   - Fix error when used on Windows Server 2012 R2 - See [Issue 102](https://github.com/PowerShell/xStorage/issues/102).
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
 - Removed requirement on Hyper-V PowerShell module to execute integration tests.
 - xMountImage:
   - Fix error when mounting VHD on Windows Server 2012 R2 - See [Issue 105](https://github.com/PowerShell/xStorage/issues/105)
-- xWaitForDisk:
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
-- Added .markdownlint.json file to configure markdown rules to validate.
 
 ## 3.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## Unreleased
 
 - xDisk:
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104).
   - Added parameter AllowDestructive - See [Issue 11](https://github.com/PowerShell/xStorage/issues/11).
   - Added parameter ClearDisk - See [Issue 50](https://github.com/PowerShell/xStorage/issues/50).
 - xDiskAccessPath:
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104).
 - xWaitForDisk:
-  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
+  - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104).
 - Added .markdownlint.json file to configure markdown rules to validate.
-- Clean up Badge area in README.MD - See [Issue 110](https://github.com/PowerShell/xStorage/issues/110)
+- Clean up Badge area in README.MD - See [Issue 110](https://github.com/PowerShell/xStorage/issues/110).
 - Disabled MD013 rule checking to enable badge table.
 
 ## 3.2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - xWaitForDisk:
   - Added support for Guid Disk Id type - See [Issue 104](https://github.com/PowerShell/xStorage/issues/104)
 - Added .markdownlint.json file to configure markdown rules to validate.
+- Clean up Badge area in README.MD - See [Issue 110](https://github.com/PowerShell/xStorage/issues/110)
 
 ## 3.2.0.0
 

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -262,7 +262,11 @@ function Set-TargetResource
             ) -join '' )
 
         $disk | Clear-Disk -RemoveData -RemoveOEM -Confirm:$true
-        $disk = $disk | Get-Disk
+
+        # Requery the disk
+        $disk = Get-DiskByIdentifier `
+            -DiskId $DiskId `
+            -DiskIdType $DiskIdType
     }
 
     switch ($disk.PartitionStyle)

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -34,7 +34,7 @@ $localizedData = Get-LocalizedData `
     Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+    Specifies the size of new volume. Leave empty to use the remaining free space.
 
     .PARAMETER FSLabel
     Specifies the volume label to assign to the volume.
@@ -66,7 +66,7 @@ function Get-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number', 'UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -104,13 +104,10 @@ function Get-TargetResource
     # Validate the DriveLetter parameter
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     $partition = Get-Partition `
         -DriveLetter $DriveLetter `
@@ -154,7 +151,7 @@ function Get-TargetResource
     Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+    Specifies the size of new volume. Leave empty to use the remaining free space.
 
     .PARAMETER FSLabel
     Specifies the volume label to assign to the volume.
@@ -187,7 +184,7 @@ function Set-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number', 'UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -225,13 +222,10 @@ function Set-TargetResource
     # Validate the DriveLetter parameter
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction Stop
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     if ($disk.IsOffline)
     {
@@ -258,7 +252,7 @@ function Set-TargetResource
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
             $($localizedData.CheckingDiskPartitionStyleMessage -f $DiskIdType, $DiskId)
-        ) -join '' )    
+        ) -join '' )
 
     if ($AllowDestructive -and $ClearDisk -and $disk.PartitionStyle -ne 'RAW')
     {
@@ -440,7 +434,7 @@ function Set-TargetResource
                             $($localizedData.ResizeRefsNotPossible `
                                     -f $DriveLetter, $assignedPartition.Size, $Size)
                         ) -join '' )
-            
+
                 }
                 else
                 {
@@ -448,10 +442,10 @@ function Set-TargetResource
                             "$($MyInvocation.MyCommand): "
                             $($localizedData.SizeMismatchCorrection `
                                     -f $DriveLetter, $assignedPartition.Size, $Size)
-                        ) -join '' )                
-                
+                        ) -join '' )
+
                     $supportedSize = ($assignedPartition | Get-PartitionSupportedSize)
-            
+
                     if ($size -gt $supportedSize.SizeMax)
                     {
                         New-InvalidArgumentException -Message ( @(
@@ -565,7 +559,7 @@ function Set-TargetResource
                 "$($MyInvocation.MyCommand): "
                 $($localizedData.SuccessfullyInitializedMessage -f $DriveLetter)
             ) -join '' )
-    } # if    
+    } # if
 } # Set-TargetResource
 
 <#
@@ -582,7 +576,7 @@ function Set-TargetResource
     Specifies the identifier type the DiskId contains. Defaults to Number.
 
     .PARAMETER Size
-    Specifies the size of new volume (use all available space on disk if not provided).
+    Specifies the size of new volume. Leave empty to use the remaining free space.
 
     .PARAMETER FSLabel
     Specifies the volume label to assign to the volume.
@@ -614,7 +608,7 @@ function Test-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number', 'UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -652,18 +646,15 @@ function Test-TargetResource
     # Validate the DriveLetter parameter
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
             $($localizedData.CheckDiskInitializedMessage -f $DiskIdType, $DiskId)
         ) -join '' )
 
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     if (-not $disk)
     {

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.schema.mof
@@ -4,7 +4,7 @@ class MSFT_xDisk : OMI_BaseResource
 {
     [Key, Description("Specifies the identifier for which disk to modify.")] String DriveLetter;
     [Required, Description("Specifies the disk identifier for the disk to modify.")] String DiskId;
-    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId"}, Values{"Number","UniqueId"}] String DiskIdType;
+    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId","Guid"}, Values{"Number","UniqueId","Guid"}] String DiskIdType;
     [Write, Description("Specifies the size of new volume. Leave empty to use the remaining free space.")] Uint64 Size;
     [Write, Description("Define volume label if required.")] String FSLabel;
     [Write, Description("Specifies the allocation unit size to use when formatting the volume.")] Uint32 AllocationUnitSize;

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/README.md
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/README.md
@@ -4,15 +4,19 @@ The resource is used to initialize, format and mount the partition/volume as a d
 letter.
 The disk to add the partition/volume to is selected by specifying the _DiskId_ and
 optionally _DiskIdType_.
-The _DiskId_ value can be a _Disk Number_ or _Unique Id_.
+The _DiskId_ value can be a _Disk Number_, _Unique Id_ or _Guid_.
 
 **Important: The _Disk Number_ is not a reliable method of selecting a disk because
 it has been shown to change between reboots in some environments.
 It is recommended to use the _Unique Id_ if possible.**
 
-The _Disk Number_ or _Unique Id_ can be identified for a disk by using the PowerShell
-command:
+The _Disk Number_, _Unique Id_ and _Guid_ can be identified for a disk by using the
+PowerShell command:
 
 ```powershell
-Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId
+Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId,Guid
 ```
+
+Note: The _Guid_ for a disk is only assigned once the partition table for the disk
+has been created (e.g. the disk has been initialized). Therefore to use this method
+of disk selection the disk must have been initialized by some other method.

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -60,7 +60,7 @@ function Get-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -90,13 +90,10 @@ function Get-TargetResource
     # Validate the AccessPath parameter adding a trailing slash
     $AccessPath = Assert-AccessPathValid -AccessPath $AccessPath -Slash
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     # Get the partitions on the disk
     $partition = $disk | Get-Partition -ErrorAction SilentlyContinue
@@ -170,7 +167,7 @@ function Set-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -200,13 +197,10 @@ function Set-TargetResource
     # Validate the AccessPath parameter adding a trailing slash
     $AccessPath = Assert-AccessPathValid -AccessPath $AccessPath -Slash
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction Stop
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     if ($disk.IsOffline)
     {
@@ -513,7 +507,7 @@ function Test-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -548,13 +542,10 @@ function Test-TargetResource
             $($localizedData.CheckDiskInitializedMessage -f $DiskIdType,$DiskId)
         ) -join '' )
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     if (-not $disk)
     {

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.schema.mof
@@ -4,7 +4,7 @@ class MSFT_xDiskAccessPath : OMI_BaseResource
 {
     [Key, Description("Specifies the access path folder to the assign the disk volume to.")] String AccessPath;
     [Required, Description("Specifies the disk identifier for the disk to modify.")] String DiskId;
-    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId"}, Values{"Number","UniqueId"}] String DiskIdType;
+    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId","Guid"}, Values{"Number","UniqueId","Guid"}] String DiskIdType;
     [Write, Description("Specifies the size of new volume.")] Uint64 Size;
     [Write, Description("Define volume label if required.")] String FSLabel;
     [Write, Description("Specifies the allocation unit size to use when formatting the volume.")] Uint32 AllocationUnitSize;

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/README.md
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/README.md
@@ -4,15 +4,19 @@ The resource is used to initialize, format and mount the partition/volume to a f
 access path.
 The disk to add the partition/volume to is selected by specifying the _DiskId_ and
 optionally _DiskIdType_.
-The _DiskId_ value can be a _Disk Number_ or _Unique Id_.
+The _DiskId_ value can be a _Disk Number_, _Unique Id_ or _Guid_.
 
 **Important: The _Disk Number_ is not a reliable method of selecting a disk because
 it has been shown to change between reboots in some environments.
 It is recommended to use the _Unique Id_ if possible.**
 
-The _Disk Number_ or _Unique Id_ can be identified for a disk by using the PowerShell
-command:
+The _Disk Number_, _Unique Id_ and _Guid_ can be identified for a disk by using the
+PowerShell command:
 
 ```powershell
-Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId
+Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId,Guid
 ```
+
+Note: The _Guid_ for a disk is only assigned once the partition table for the disk
+has been created (e.g. the disk has been initialized). Therefore to use this method
+of disk selection the disk must have been initialized by some other method.

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.psm1
@@ -47,7 +47,7 @@ function Get-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -100,7 +100,7 @@ function Set-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -120,15 +120,14 @@ function Set-TargetResource
 
     $diskFound = $false
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
 
     for ($count = 0; $count -lt $RetryCount; $count++)
     {
-        $disk = Get-Disk `
-            @diskIdParameter `
-            -ErrorAction SilentlyContinue
+        # Get the Disk using the identifiers supplied
+        $disk = Get-DiskByIdentifier `
+            -DiskId $DiskId `
+            -DiskIdType $DiskIdType
+
         if ($disk)
         {
             Write-Verbose -Message ( @(
@@ -184,7 +183,7 @@ function Test-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId')]
+        [ValidateSet('Number','UniqueId','Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -202,13 +201,10 @@ function Test-TargetResource
             $($localizedData.CheckingForDiskStatusMessage -f $DiskIdType,$DiskId)
         ) -join '' )
 
-    $diskIdParameter = @{
-        $DiskIdType = $DiskId
-    }
-
-    $disk = Get-Disk `
-        @diskIdParameter `
-        -ErrorAction SilentlyContinue
+    # Get the Disk using the identifiers supplied
+    $disk = Get-DiskByIdentifier `
+        -DiskId $DiskId `
+        -DiskIdType $DiskIdType
 
     if ($disk)
     {

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/MSFT_xWaitForDisk.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xWaitForDisk : OMI_BaseResource
 {
     [Key, Description("Specifies the disk identifier for the disk to wait for.")] String DiskId;
-    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId"}, Values{"Number","UniqueId"}] String DiskIdType;
+    [Write, Description("Specifies the identifier type the DiskId contains. Defaults to Number."), ValueMap{"Number","UniqueId","Guid"}, Values{"Number","UniqueId","Guid"}] String DiskIdType;
     [Write, Description("Specifies the number of seconds to wait for the disk to become available.")] Uint32 RetryIntervalSec;
     [Write, Description("The number of times to loop the retry interval while waiting for the disk.")] Uint32 RetryCount;
 };

--- a/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/README.md
+++ b/Modules/xStorage/DSCResources/MSFT_xWaitForDisk/README.md
@@ -3,15 +3,19 @@
 This resource is used to wait for a disk to become available.
 The disk to wait for is selected by specifying the _DiskId_ and optionally
 _DiskIdType_.
-The _DiskId_ value can be a _Disk Number_ or _Unique Id_.
+The _DiskId_ value can be a _Disk Number_, _Unique Id_ or _Guid_.
 
 **Important: The _Disk Number_ is not a reliable method of selecting a disk because
 it has been shown to change between reboots in some environments.
 It is recommended to use the _Unique Id_ if possible.**
 
-The _Disk Number_ or _Unique Id_ can be identified for a disk by using the PowerShell
-command:
+The _Disk Number_, _Unique Id_ and _Guid_ can be identified for a disk by using the
+PowerShell command:
 
 ```powershell
-Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId
+Get-Disk | Select-Object -Property FriendlyName,DiskNumber,UniqueId,Guid
 ```
+
+Note: The _Guid_ for a disk is only assigned once the partition table for the disk
+has been created (e.g. the disk has been initialized). Therefore to use this method
+of disk selection the disk must have been initialized by some other method.

--- a/Modules/xStorage/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/xStorage/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -104,4 +104,56 @@ function Assert-AccessPathValid
     return $AccessPath
 } # end function Assert-AccessPathValid
 
-Export-ModuleMember -Function @( 'Assert-DriveLetterValid', 'Assert-AccessPathValid' )
+
+<#
+    .SYNOPSIS
+    Retrieves a Disk object matching the disk Id and Id type
+    provided.
+
+    .PARAMETER DiskId
+    Specifies the disk identifier for the disk to retrieve.
+
+    .PARAMETER DiskIdType
+    Specifies the identifier type the DiskId contains. Defaults to Number.
+#>
+function Get-DiskByIdentifier
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DiskId,
+
+        [Parameter()]
+        [ValidateSet('Number','UniqueId','Guid')]
+        [System.String]
+        $DiskIdType = 'Number'
+    )
+
+    if ($DiskIdType -eq 'Guid')
+    {
+        # The Disk Id requested uses a Guid so have to get all disks and filter
+        $disk = Get-Disk `
+            -ErrorAction SilentlyContinue |
+            Where-Object -Property Guid -EQ $DiskId
+    }
+    else
+    {
+        $diskIdParameter = @{
+            $DiskIdType = $DiskId
+        }
+
+        $disk = Get-Disk `
+            @diskIdParameter `
+            -ErrorAction SilentlyContinue
+    }
+
+    return $disk
+} # end function Get-DiskByIdentifier
+
+Export-ModuleMember -Function `
+    Assert-DriveLetterValid, `
+    Assert-AccessPathValid, `
+    Get-DiskByIdentifier

--- a/Modules/xStorage/xStorage.psd1
+++ b/Modules/xStorage/xStorage.psd1
@@ -10,7 +10,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '3.0.0.0'
+ModuleVersion = '3.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = '00d73ca1-58b5-46b7-ac1a-5bfcf5814faf'
@@ -102,41 +102,9 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '- Converted AppVeyor build process to use AppVeyor.psm1.
-- Added support for auto generating wiki, help files, markdown linting
-  and checking examples.
-- Correct name of MSFT_xDiskAccessPath.tests.ps1.
-- Move shared modules into Modules folder.
-- Fixed unit tests.
-- Removed support for WMI cmdlets.
-- Opted in to Markdown and Example tests.
-- Added CodeCov.io support.
-- Removed requirement on using Pester 3.4.6 because Pester bug fixed in 4.0.3.
-- Fixed unit tests for MSFT_xDiskAccessPath resource to be compatible with
-  Pester 4.0.3.
-- xDisk:
-  - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to enable it to
-    contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
-  - Added DiskIdType parameter to enable specifying the type of identifer
-    the DiskId parameter contains - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
-  - Changed to use xDiskAccessPath pattern to fix issue with Windows Server
-    2016 - See [Issue 80](https://github.com/PowerShell/xStorage/issues/80).
-  - Fixed style violations in xDisk.
-  - Fixed issue when creating multiple partitions on a single disk with no size
-    specified - See [Issue 86](https://github.com/PowerShell/xStorage/issues/86).
-- xDiskAccessPath:
-  - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to
-    enable it to contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
-  - Added DiskIdType parameter to enable specifying the type
-    of identifer the DiskId parameter contains - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
-  - Fixed incorrect logging messages when changing volume label.
-  - Fixed issue when creating multiple partitions on a single disk with no size
-    specified - See [Issue 86](https://github.com/PowerShell/xStorage/issues/86).
-- xWaitForDisk:
-  - BREAKING CHANGE: Renamed parameter DiskNumber to DiskId to
-    enable it to contain either DiskNumber or UniqueId - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
-  - Added DiskIdType parameter to enable specifying the type
-    of identifer the DiskId parameter contains - See [Issue 81](https://github.com/PowerShell/xStorage/issues/81).
+        ReleaseNotes = '- Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
 
 '
 
@@ -151,6 +119,7 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # xStorage
 
-| Branch | Build Status | Code Coverage |
-| --- | --- | --- |
-| master | [![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/master) |
-| dev | [![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/dev) |
-
 The **xStorage** module contains the following resources:
 
 - **xMountImage**: used to mount or unmount an ISO/VHD disk image. It can be
@@ -19,6 +14,25 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
+
+## Branches
+
+### master
+
+[![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master)
+[![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/master)
+
+This is the branch containing the latest release - no contributions should be made
+directly to this branch.
+
+### dev
+
+[![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/dev)
+[![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/dev)
+
+This is the development branch to which contributions should be proposed by contributors
+as pull requests. This development branch will periodically be merged to the master
+branch, and be released to [PowerShell Gallery](https://www.powershellgallery.com/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # xStorage
 
-[![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master)
-[![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage)
+| Branch | Build Status | Code Coverage |
+| --- | --- | --- |
+| master | [![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/master) |
+| dev | [![Build status](https://ci.appveyor.com/api/projects/status/1j95juvceu39ekm7/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xstorage/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xStorage/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xStorage/branch/dev) |
 
 The **xStorage** module contains the following resources:
 

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xStorage'
-$script:DSCResourceName    = 'MSFT_xDisk'
+$script:DSCModuleName = 'xStorage'
+$script:DSCResourceName = 'MSFT_xDisk'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
@@ -7,9 +7,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Integration Test Template Version: 1.1.1
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -25,8 +25,8 @@ try
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    #region Integration Tests for DiskNumber
     Describe "$($script:DSCResourceName)_Integration" {
+        #region Integration Tests for DiskNumber
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Drive Letters' {
             BeforeAll {
                 # Create a VHD and attach it to the computer
@@ -41,8 +41,8 @@ try
 
                 # Get a spare drive letters
                 $lastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
-                $driveLetterA = [char](([int][char]$lastDrive)+1)
-                $driveLetterB = [char](([int][char]$lastDrive)+2)
+                $driveLetterA = [char](([int][char]$lastDrive) + 1)
+                $driveLetterB = [char](([int][char]$lastDrive) + 2)
             }
 
             #region DEFAULT TESTS
@@ -147,11 +147,8 @@ try
                 Remove-Item -Path $VHDPath -Force
             }
         }
-    }
-    #endregion
 
-    #region Integration Tests for Disk Unique Id
-    Describe "$($script:DSCResourceName)_Integration" {
+        #region Integration Tests for Disk Unique Id
         Context 'Partition and format newly provisioned disk using Unique Id with two volumes and assign Drive Letters' {
             BeforeAll {
                 # Create a VHD and attach it to the computer
@@ -166,8 +163,8 @@ try
 
                 # Get a spare drive letter
                 $lastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
-                $driveLetterA = [char](([int][char]$lastDrive)+1)
-                $driveLetterB = [char](([int][char]$lastDrive)+2)
+                $driveLetterA = [char](([int][char]$lastDrive) + 1)
+                $driveLetterB = [char](([int][char]$lastDrive) + 2)
             }
 
             #region DEFAULT TESTS
@@ -177,12 +174,12 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName      = 'localhost'
-                                DriveLetter   = $driveLetterA
-                                DiskId        = $disk.UniqueId
-                                DiskIdType    = 'UniqueId'
-                                FSLabel       = $FSLabelA
-                                Size          = 100MB
+                                NodeName    = 'localhost'
+                                DriveLetter = $driveLetterA
+                                DiskId      = $disk.UniqueId
+                                DiskIdType  = 'UniqueId'
+                                FSLabel     = $FSLabelA
+                                Size        = 100MB
                             }
                         )
                     }
@@ -259,11 +256,11 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName      = 'localhost'
-                                DriveLetter   = $driveLetterB
-                                DiskId        = $disk.UniqueId
-                                DiskIdType    = 'UniqueId'
-                                FSLabel       = $FSLabelB
+                                NodeName    = 'localhost'
+                                DriveLetter = $driveLetterB
+                                DiskId      = $disk.UniqueId
+                                DiskIdType  = 'UniqueId'
+                                FSLabel     = $FSLabelB
                             }
                         )
                     }
@@ -289,6 +286,124 @@ try
                 $current.DriveLetter      | Should Be $driveLetterB
                 $current.FSLabel          | Should Be $FSLabelB
                 $current.Size             | Should Be 96337920
+            }
+
+            # A system partition will have been added to the disk as well as the 2 test partitions
+            It 'Should have 3 partitions on disk' {
+                ($disk | Get-Partition).Count | Should Be 3
+            }
+
+            It "should have attached drive $driveLetterA" {
+                Get-PSDrive -Name $driveLetterA -ErrorAction SilentlyContinue | Should Not BeNullOrEmpty
+            }
+
+            It "should have attached drive $driveLetterB" {
+                Get-PSDrive -Name $driveLetterB -ErrorAction SilentlyContinue | Should Not BeNullOrEmpty
+            }
+
+            AfterAll {
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
+            }
+        }
+        #endregion
+
+        #region Integration Tests for Disk Guid
+        Context 'Partition and format newly provisioned disk using Guid with two volumes and assign Drive Letters' {
+            BeforeAll {
+                # Create a VHD and attach it to the computer
+                $VHDPath = Join-Path -Path $TestDrive `
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Initialize
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
+                $FSLabelA = 'TestDiskA'
+                $FSLabelB = 'TestDiskB'
+
+                # Get a spare drive letter
+                $lastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
+                $driveLetterA = [char](([int][char]$lastDrive) + 1)
+                $driveLetterB = [char](([int][char]$lastDrive) + 2)
+            }
+
+            #region DEFAULT TESTS
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName    = 'localhost'
+                                DriveLetter = $driveLetterA
+                                DiskId      = $disk.Guid
+                                DiskIdType  = 'Guid'
+                                FSLabel     = $FSLabelA
+                                Size        = 100MB
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            }
+            #endregion
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $disk.Guid
+                $current.DriveLetter      | Should Be $driveLetterA
+                $current.FSLabel          | Should Be $FSLabelA
+                $current.Size             | Should Be 100MB
+            }
+
+            #region DEFAULT TESTS
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName    = 'localhost'
+                                DriveLetter = $driveLetterB
+                                DiskId      = $disk.Guid
+                                DiskIdType  = 'Guid'
+                                FSLabel     = $FSLabelB
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            }
+            #endregion
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $disk.Guid
+                $current.DriveLetter      | Should Be $driveLetterB
+                $current.FSLabel          | Should Be $FSLabelB
+                $current.Size             | Should Be 935198720
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xStorage'
-$script:DSCResourceName    = 'MSFT_xDiskAccessPath'
+$script:DSCModuleName = 'xStorage'
+$script:DSCResourceName = 'MSFT_xDiskAccessPath'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
@@ -7,9 +7,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Integration Test Template Version: 1.1.1
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -25,8 +25,8 @@ try
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    #region Integration Tests for DiskNumber
     Describe "$($script:DSCResourceName)_Integration" {
+        #region Integration Tests for DiskNumber
         Context 'Partition and format newly provisioned disk using Disk Number with two volumes and assign Access Paths' {
             BeforeAll {
                 # Create a VHD and attach it to the computer
@@ -60,12 +60,12 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathA
-                                DiskId      = $disk.Number
-                                DiskIdType  = 'Number'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.Number
+                                DiskIdType = 'Number'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
                             }
                         )
                     }
@@ -111,12 +111,12 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathA
-                                DiskId      = $disk.Number
-                                DiskIdType  = 'Number'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.Number
+                                DiskIdType = 'Number'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
                             }
                         )
                     }
@@ -154,11 +154,11 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathB
-                                DiskId      = $disk.Number
-                                DiskIdType  = 'Number'
-                                FSLabel     = $FSLabelB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathB
+                                DiskId     = $disk.Number
+                                DiskIdType = 'Number'
+                                FSLabel    = $FSLabelB
                             }
                         )
                     }
@@ -243,12 +243,12 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathA
-                                DiskId      = $disk.UniqueId
-                                DiskIdType  = 'UniqueId'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.UniqueId
+                                DiskIdType = 'UniqueId'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
                             }
                         )
                     }
@@ -294,12 +294,12 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathA
-                                DiskId      = $disk.UniqueId
-                                DiskIdType  = 'UniqueId'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.UniqueId
+                                DiskIdType = 'UniqueId'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
                             }
                         )
                     }
@@ -337,11 +337,11 @@ try
                     $configData = @{
                         AllNodes = @(
                             @{
-                                NodeName    = 'localhost'
-                                AccessPath  = $accessPathB
-                                DiskId      = $disk.UniqueId
-                                DiskIdType  = 'UniqueId'
-                                FSLabel     = $FSLabelB
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathB
+                                DiskId     = $disk.UniqueId
+                                DiskIdType = 'UniqueId'
+                                FSLabel    = $FSLabelB
                             }
                         )
                     }
@@ -390,6 +390,190 @@ try
                 $null = Remove-Item -Path $VHDPath -Force
             }
         }
+        #endregion
+
+        #region Integration Tests for Disk Guid
+        Context 'Partition and format newly provisioned disk using Disk Guid with two volumes and assign Access Paths' {
+            BeforeAll {
+                # Create a VHD and attach it to the computer
+                $VHDPath = Join-Path -Path $TestDrive `
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Initialize
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
+                $FSLabelA = 'TestDiskA'
+                $FSLabelB = 'TestDiskB'
+
+                # Get a couple of mount point paths
+                $accessPathA = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountA'
+                if (-not (Test-Path -Path $accessPathA))
+                {
+                    $null = New-Item -Path $accessPathA -ItemType Directory
+                } # if
+
+                $accessPathB = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountB'
+                if (-not (Test-Path -Path $accessPathB))
+                {
+                    $null = New-Item -Path $accessPathB -ItemType Directory
+                } # if
+            }
+
+            #region DEFAULT TESTS
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.Guid
+                                DiskIdType = 'Guid'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should not throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $disk.Guid
+                $current.AccessPath       | Should Be "$($accessPathA)\"
+                $current.FSLabel          | Should Be $FSLabelA
+                $current.Size             | Should Be 100MB
+            }
+
+            # Create a file on the new disk to ensure it still exists after reattach
+            $testFilePath = Join-Path -Path $accessPathA -ChildPath 'IntTestFile.txt'
+            Set-Content `
+                -Path $testFilePath `
+                -Value 'Test' `
+                -NoNewline
+
+            # This test will ensure the disk can be remounted if the access path is removed.
+            Remove-PartitionAccessPath `
+                -DiskNumber $disk.Number `
+                -PartitionNumber 2 `
+                -AccessPath $accessPathA
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathA
+                                DiskId     = $disk.Guid
+                                DiskIdType = 'Guid'
+                                FSLabel    = $FSLabelA
+                                Size       = 100MB
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should not throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $disk.Guid
+                $current.AccessPath       | Should Be "$($accessPathA)\"
+                $current.FSLabel          | Should Be $FSLabelA
+                $current.Size             | Should Be 100MB
+            }
+
+            It 'Should contain the test file' {
+                Test-Path -Path $testFilePath        | Should Be $true
+                Get-Content -Path $testFilePath -Raw | Should Be 'Test'
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName   = 'localhost'
+                                AccessPath = $accessPathB
+                                DiskId     = $disk.Guid
+                                DiskIdType = 'Guid'
+                                FSLabel    = $FSLabelB
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive `
+                        -ComputerName localhost -Wait -Verbose -Force
+                } | Should not throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $disk.Guid
+                $current.AccessPath       | Should Be "$($accessPathB)\"
+                $current.FSLabel          | Should Be $FSLabelB
+                $current.Size             | Should Be 935198720
+            }
+
+            # A system partition will have been added to the disk as well as the 2 test partitions
+            It 'Should have 3 partitions on disk' {
+                ($disk | Get-Partition).Count | Should Be 3
+            }
+            #endregion
+
+            AfterAll {
+                # Clean up
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
+                    -PartitionNumber 2 `
+                    -AccessPath $accessPathA
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
+                    -PartitionNumber 3 `
+                    -AccessPath $accessPathB
+                $null = Remove-Item -Path $accessPathA -Force
+                $null = Remove-Item -Path $accessPathB -Force
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
+            }
+        }
+        #endregion
     }
     #endregion
 }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -75,7 +75,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -126,7 +126,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -168,7 +168,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -258,7 +258,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -309,7 +309,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -351,7 +351,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -441,7 +441,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -492,7 +492,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -534,7 +534,7 @@ try
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_ISO.Integration.Tests.ps1
@@ -67,7 +67,7 @@ try
                         -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -102,7 +102,7 @@ try
                         -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMountImage_VHD.Integration.Tests.ps1
@@ -64,7 +64,7 @@ try
                         -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -99,7 +99,7 @@ try
                         -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $TestDrive `
                         -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
@@ -52,7 +52,7 @@ try
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -92,7 +92,7 @@ try
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -132,7 +132,7 @@ try
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForDisk.Integration.Tests.ps1
@@ -109,6 +109,46 @@ try
                 $current.RetryCount       | Should Be 5
             }
         }
+
+        Context 'Wait for a Disk using Disk Guid' {
+            #region DEFAULT TESTS
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName         = 'localhost'
+                                DiskId           = $disk.Guid
+                                DiskIdType       = 'Guid'
+                                RetryIntervalSec = 1
+                                RetryCount       = 5
+                            }
+                        )
+                    }
+
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+                    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+                } | Should not throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+            #endregion
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration | Where-Object {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $current.DiskId           | Should Be $Disk.Guid
+                $current.RetryIntervalSec | Should Be 1
+                $current.RetryCount       | Should Be 5
+            }
+        }
     }
     #endregion
 }

--- a/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWaitForVolume.Integration.Tests.ps1
@@ -33,7 +33,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-                } | Should not throw
+                } | Should Not Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -85,6 +85,15 @@ function Get-InvalidOperationRecord
     .SYNOPSIS
     Creates a new VHD using DISKPART.
     DISKPART is used because New-VHD is only available if Hyper-V is installed.
+
+    .PARAMETER Path
+    The path to the VHD file to create.
+
+    .PARAMETER SizeInMB
+    The size of the VHD disk to create.
+
+    .PARAMETER Initialize
+    Should the disk be initialized? This is for testing matching disks by GUID.
 #>
 function New-VDisk
 {
@@ -97,14 +106,33 @@ function New-VDisk
 
         [Parameter()]
         [Uint32]
-        $SizeInMB
+        $SizeInMB,
+
+        [Parameter()]
+        [Switch]
+        $Initialize
     )
 
     $tempScriptPath = Join-Path -Path $ENV:Temp -ChildPath 'DiskPartVdiskScript.txt'
     Write-Verbose -Message ('Creating DISKPART script {0}' -f $tempScriptPath)
+
+    $diskPartScript = "CREATE VDISK FILE=`"$Path`" TYPE=EXPANDABLE MAXIMUM=$SizeInMB"
+
+    if ($Initialize)
+    {
+        # The disk will be initialized with GPT
+        $diskPartScript += @"
+
+SELECT VDISK FILE=`"$Path`"
+ATTACH VDISK
+CONVERT GPT
+DETACH VDISK
+"@
+    }
+
     Set-Content `
         -Path $tempScriptPath `
-        -Value "create vdisk FILE=`"$Path`" TYPE=EXPANDABLE MAXIMUM=$SizeInMB" `
+        -Value $diskPartScript `
         -Encoding Ascii
     $result = & DISKPART @('/s',$tempScriptPath)
     Write-Verbose -Message ($Result | Out-String)

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -122,7 +122,6 @@ function New-VDisk
     {
         # The disk will be initialized with GPT
         $diskPartScript += @"
-
 SELECT VDISK FILE=`"$Path`"
 ATTACH VDISK
 CONVERT GPT

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -120,8 +120,9 @@ function New-VDisk
 
     if ($Initialize)
     {
-        # The disk will be initialized with GPT
+        # The disk will be initialized with GPT (first blank line required because we're adding to existing string)
         $diskPartScript += @"
+
 SELECT VDISK FILE=`"$Path`"
 ATTACH VDISK
 CONVERT GPT

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -329,27 +329,27 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "Should be DiskId $($script:mockedDisk0.Number)" {
+                It "Should return DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "Should be DriveLetter $($script:testDriveLetter)" {
+                It "Should return DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Should have size $($script:mockedPartition.Size)" {
+                It "Should return size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "Should be FSLabel $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "Should be AllocationUnitSize $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "Should be FSFormat $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -392,27 +392,27 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "Should be DiskId $($script:mockedDisk0.UniqueId)" {
+                It "Should return DiskId $($script:mockedDisk0.UniqueId)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.UniqueId
                 }
 
-                It "Should be DriveLetter $($script:testDriveLetter)" {
+                It "Should return DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Should have size $($script:mockedPartition.Size)" {
+                It "Should return size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "Should be FSLabel $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "Should be AllocationUnitSize $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "Should be FSFormat $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -455,27 +455,27 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Guid)" {
+                It "Should return DiskId $($script:mockedDisk0.Guid)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Guid
                 }
 
-                It "DriveLetter should be $($script:testDriveLetter)" {
+                It "Should return DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should return Size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -518,27 +518,27 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Guid)" {
+                It "Should return DiskId $($script:mockedDisk0.Guid)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Guid
                 }
 
-                It "DriveLetter should be $($script:testDriveLetter)" {
+                It "Should return DriveLetter $($script:testDriveLetter)" {
                     $resource.DriveLetter | Should Be $script:testDriveLetter
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should return Size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -577,27 +577,27 @@ try
                     -DriveLetter $script:testDriveLetter `
                     -Verbose
 
-                It "Should be DiskId $($script:mockedDisk0.Number)" {
+                It "Should return DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "Should have an empty drive letter" {
+                It "Should return an empty drive letter" {
                     $resource.DriveLetter | Should Be $null
                 }
 
-                It "Should have a zero size" {
+                It "Should return a zero size" {
                     $resource.Size | Should Be $null
                 }
 
-                It "Should have no FSLabel" {
+                It "Should return no FSLabel" {
                     $resource.FSLabel | Should Be ''
                 }
 
-                It "Should have an AllocationUnitSize of 0" {
+                It "Should return an AllocationUnitSize of 0" {
                     $resource.AllocationUnitSize | Should Be $null
                 }
 
-                It "Should have no FSFormat" {
+                It "Should return no FSFormat" {
                     $resource.FSFormat | Should Be $null
                 }
 
@@ -653,13 +653,13 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -717,14 +717,14 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0Offline.UniqueId `
                             -DiskIdType 'UniqueId' `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -784,14 +784,14 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Guid `
                             -DiskIdType 'Guid' `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -851,13 +851,13 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0Readonly.Number `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -918,13 +918,13 @@ try
                     -CommandName Set-Partition `
                     -Verifiable
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0OfflineRaw.Number `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -984,7 +984,7 @@ try
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0Raw.Number `
@@ -993,7 +993,7 @@ try
                             -AllocationUnitSize 64 `
                             -FSLabel 'MyDisk' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1050,13 +1050,13 @@ try
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1295,13 +1295,13 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Set-Partition
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -DriveLetter $script:testDriveLetter `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1346,14 +1346,14 @@ try
                 Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -DriveLetter $script:testDriveLetter `
                             -Size $script:mockedPartitionSize `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1406,13 +1406,13 @@ try
                 Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -Driveletter 'H' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1458,14 +1458,14 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Set-Partition
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -Driveletter $script:testDriveLetter `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1518,7 +1518,7 @@ try
                 Mock -CommandName Get-PartitionSupportedSize
                 Mock -CommandName Set-Volume
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1527,7 +1527,7 @@ try
                             -AllowDestructive $true `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1636,7 +1636,7 @@ try
                 Mock -CommandName Resize-Partition
                  Mock  -CommandName Get-PartitionSupportedSize
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1646,7 +1646,7 @@ try
                             -FSLabel 'NewLabel' `
                             -FSFormat 'ReFS' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1698,7 +1698,7 @@ try
                 Mock -CommandName New-Partition
                 Mock -CommandName Set-Partition
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1708,7 +1708,7 @@ try
                             -FSLabel 'NewLabel' `
                             -AllowDestructive $true `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1757,7 +1757,7 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Set-Partition
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1767,7 +1767,7 @@ try
                             -AllowDestructive $true `
                             -ClearDisk $true `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1808,14 +1808,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw when calling Test-TargetResource' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should return false' {
@@ -1847,14 +1847,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -1886,7 +1886,7 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.UniqueId `
@@ -1894,7 +1894,7 @@ try
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -1926,7 +1926,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Guid `
@@ -1934,7 +1934,7 @@ try
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should return false' {
@@ -1966,14 +1966,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Readonly.Number `
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2005,14 +2005,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Raw.Number `
                             -DriveLetter $script:testDriveLetter `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2054,7 +2054,7 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2062,10 +2062,10 @@ try
                             -AllocationUnitSize 4096 `
                             -Size ($script:mockedPartitionSize + 1MB) `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'Sshould be true' {
+                It 'Should be true' {
                     $script:result | Should Be $true
                 }
 
@@ -2101,7 +2101,7 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2109,7 +2109,7 @@ try
                             -AllocationUnitSize 4097 `
                             -AllowDestructive $true `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2150,14 +2150,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -DriveLetter $script:testDriveLetter `
                             -FSFormat 'ReFS' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be true' {
@@ -2199,7 +2199,7 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2207,7 +2207,7 @@ try
                             -FSFormat 'ReFS' `
                             -AllowDestructive $true `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2249,14 +2249,14 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -DriveLetter $script:testDriveLetter `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2296,13 +2296,13 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -DriveLetter 'Z' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be false' {
@@ -2344,7 +2344,7 @@ try
 
                 $script:result = $null
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -2354,7 +2354,7 @@ try
                             -FSLabel $script:mockedVolume.FileSystemLabel `
                             -FSFormat $script:mockedVolume.FileSystem `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should be true' {

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -664,16 +664,16 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 1
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter { $DriveLetter -eq $script:testDriveLetter }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -729,18 +729,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.UniqueId -and $DiskIdType -eq 'UniqueId' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 1
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -796,18 +796,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.Guid -and $DiskIdType -eq 'Guid' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 1
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -862,18 +862,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 1
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -929,18 +929,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 1
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 1
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -998,18 +998,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 1
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -1061,18 +1061,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -1124,19 +1124,19 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName New-Partition -Times 1 `
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 31
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
                     }
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                 }
             }
 
@@ -1172,15 +1172,15 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                 }
             }
 
@@ -1216,14 +1216,14 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                 }
             }
 
@@ -1259,14 +1259,14 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                 }
             }
 
@@ -1306,15 +1306,15 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
                 }
             }
 
@@ -1358,15 +1358,15 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -1417,15 +1417,15 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
                 }
             }
 
@@ -1470,16 +1470,16 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
                 }
             }
 
@@ -1532,16 +1532,16 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 1
-                    Assert-MockCalled -CommandName Set-Partition -Times 1
-                    Assert-MockCalled -CommandName Set-Volume -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 0
                 }
             }
 
@@ -1592,16 +1592,16 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 0
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 0
                 }
             }
 
@@ -1651,18 +1651,18 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 1
-                    Assert-MockCalled -CommandName Resize-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Times 0
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Resize-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-PartitionSupportedSize -Exactly -Times 0
                 }
             }
 
@@ -1713,15 +1713,15 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
                 }
             }
 
@@ -1772,16 +1772,16 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 2 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Set-Disk -Times 0
-                    Assert-MockCalled -CommandName Initialize-Disk -Times 0
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName New-Partition -Times 0
-                    Assert-MockCalled -CommandName Format-Volume -Times 0
-                    Assert-MockCalled -CommandName Set-Partition -Times 0
-                    Assert-MockCalled -CommandName Set-Volume -Times 1
+                    Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName New-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Set-Volume -Exactly -Times 1
                 }
             }
         }
@@ -1824,11 +1824,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -1863,11 +1863,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -1903,11 +1903,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.UniqueId -and $DiskIdType -eq 'UniqueId' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -1943,11 +1943,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Offline.Guid -and $DiskIdType -eq 'Guid' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -1982,11 +1982,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0Readonly.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -2021,11 +2021,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 0
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -2071,11 +2071,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 
@@ -2118,10 +2118,10 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 
@@ -2166,11 +2166,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 
@@ -2216,11 +2216,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 
@@ -2265,11 +2265,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
 
@@ -2311,11 +2311,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 0
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 0
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0
                 }
             }
 
@@ -2363,11 +2363,11 @@ try
 
                 It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1 `
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
                         -ParameterFilter { $DiskId -eq $script:mockedDisk0.Number -and $DiskIdType -eq 'Number' }
-                    Assert-MockCalled -CommandName Get-Partition -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance -Times 1
+                    Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xStorage'
-$script:DSCResourceName    = 'MSFT_xDiskAccessPath'
+$script:DSCModuleName = 'xStorage'
+$script:DSCResourceName = 'MSFT_xDiskAccessPath'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
@@ -7,9 +7,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -29,102 +29,106 @@ try
     InModuleScope $script:DSCResourceName {
         #region Pester Test Initialization
         $script:testAccessPath = 'c:\TestAccessPath'
+        $script:testDiskNumber = 1
         $script:testDiskUniqueId = 'TESTDISKUNIQUEID'
+        $script:testDiskGptGuid = [guid]::NewGuid()
+        $script:testDiskMbrGuid = '123456'
 
         $script:mockedDisk0 = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'GPT'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0Mbr = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'MBR'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'MBR'
+        }
 
         $script:mockedDisk0Offline = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $true
-                IsReadOnly = $false
-                PartitionStyle = 'GPT'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $true
+            IsReadOnly     = $false
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0OfflineRaw = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $true
-                IsReadOnly = $false
-                PartitionStyle = 'Raw'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $true
+            IsReadOnly     = $false
+            PartitionStyle = 'Raw'
+        }
 
         $script:mockedDisk0Readonly = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $true
-                PartitionStyle = 'GPT'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $true
+            PartitionStyle = 'GPT'
+        }
 
         $script:mockedDisk0Raw = [pscustomobject] @{
-                Number = 0
-                UniqueId = $script:testDiskUniqueId
-                IsOffline = $false
-                IsReadOnly = $false
-                PartitionStyle = 'Raw'
-            }
+            Number         = $script:testDiskNumber
+            UniqueId       = $script:testDiskUniqueId
+            IsOffline      = $false
+            IsReadOnly     = $false
+            PartitionStyle = 'Raw'
+        }
 
-        $script:mockedCim = [pscustomobject] @{BlockSize=4096}
+        $script:mockedCim = [pscustomobject] @{BlockSize = 4096}
 
         $script:mockedPartitionSize = 1GB
 
         $script:mockedPartition = [pscustomobject] @{
-                AccessPaths = @(
-                    '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
-                    $script:testAccessPath
-                )
-                Size = $script:mockedPartitionSize
-                PartitionNumber = 1
-                Type = 'Basic'
-            }
+            AccessPaths     = @(
+                '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
+                $script:testAccessPath
+            )
+            Size            = $script:mockedPartitionSize
+            PartitionNumber = 1
+            Type            = 'Basic'
+        }
 
         $script:mockedPartitionNoAccess = [pscustomobject] @{
-                AccessPaths = @(
-                    '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
-                )
-                Size = $script:mockedPartitionSize
-                PartitionNumber = 1
-                Type = 'Basic'
-            }
+            AccessPaths     = @(
+                '\\?\Volume{2d313fdd-e4a4-4f31-9784-dad758e0030f}\'
+            )
+            Size            = $script:mockedPartitionSize
+            PartitionNumber = 1
+            Type            = 'Basic'
+        }
 
         $script:mockedVolume = [pscustomobject] @{
-                FileSystemLabel = 'myLabel'
-                FileSystem = 'NTFS'
-            }
+            FileSystemLabel = 'myLabel'
+            FileSystem      = 'NTFS'
+        }
 
         $script:mockedVolumeUnformatted = [pscustomobject] @{
-                FileSystemLabel = ''
-                FileSystem = ''
-            }
+            FileSystemLabel = ''
+            FileSystem      = ''
+        }
 
         $script:mockedVolumeReFS = [pscustomobject] @{
-                FileSystemLabel = 'myLabel'
-                FileSystem = 'ReFS'
-            }
+            FileSystemLabel = 'myLabel'
+            FileSystem      = 'ReFS'
+        }
         #endregion
 
         #region functions for mocking pipeline
         # These functions are required to be able to mock functions where
         # values are passed in via the pipeline.
-        function Set-Disk {
+        function Set-Disk
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $InputObject,
 
@@ -136,10 +140,11 @@ try
             )
         }
 
-        function Initialize-Disk {
+        function Initialize-Disk
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $InputObject,
 
@@ -148,10 +153,11 @@ try
             )
         }
 
-        function Get-Partition {
+        function Get-Partition
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $Disk,
 
@@ -160,10 +166,11 @@ try
             )
         }
 
-        function New-Partition {
+        function New-Partition
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline)]
                 $Disk,
 
@@ -175,19 +182,21 @@ try
             )
         }
 
-        function Get-Volume {
+        function Get-Volume
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $Partition
             )
         }
 
-        function Set-Volume {
+        function Set-Volume
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $InputObject,
 
@@ -196,10 +205,11 @@ try
             )
         }
 
-        function Format-Volume {
+        function Format-Volume
+        {
+            [CmdletBinding()]
             Param
             (
-                [CmdletBinding()]
                 [Parameter(ValueFromPipeline = $true)]
                 $Partition,
 
@@ -214,7 +224,9 @@ try
             )
         }
 
-        function Add-PartitionAccessPath {
+        function Add-PartitionAccessPath
+        {
+            [CmdletBinding()]
             Param
             (
                 [String]
@@ -244,7 +256,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -287,10 +299,10 @@ try
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
-                    Assert-MockCalled -CommandName Get-Disk -Exactly 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly 1
                     Assert-MockCalled -CommandName Get-Partition -Exactly 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly 1
                 }
@@ -309,7 +321,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -353,10 +365,10 @@ try
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
-                    Assert-MockCalled -CommandName Get-Disk -Exactly 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly 1
                     Assert-MockCalled -CommandName Get-Partition -Exactly 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly 1
                 }
@@ -374,7 +386,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -414,10 +426,10 @@ try
                     $resource.FSFormat | Should Be $null
                 }
 
-                It 'all the get mocks should be called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly 1
-                    Assert-MockCalled -CommandName Get-Disk -Exactly 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly 1
                     Assert-MockCalled -CommandName Get-Partition -Exactly 1
                     Assert-MockCalled -CommandName Get-Volume -Exactly 0
                 }
@@ -435,7 +447,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Offline } `
                     -Verifiable
 
@@ -477,10 +489,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -499,7 +511,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Offline } `
                     -Verifiable
 
@@ -542,10 +554,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -564,7 +576,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Readonly } `
                     -Verifiable
 
@@ -606,10 +618,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -628,7 +640,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0OfflineRaw } `
                     -Verifiable
 
@@ -673,10 +685,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 1
                     Assert-MockCalled -CommandName Initialize-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -695,7 +707,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Raw } `
                     -Verifiable
 
@@ -737,10 +749,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -759,7 +771,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -798,10 +810,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -820,7 +832,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Mbr } `
                     -Verifiable
 
@@ -835,7 +847,7 @@ try
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.DiskAlreadyInitializedError -f `
-                        'Number',$script:mockedDisk0Mbr.Number,$script:mockedDisk0Mbr.PartitionStyle)
+                        'Number', $script:mockedDisk0Mbr.Number, $script:mockedDisk0Mbr.PartitionStyle)
 
                 It 'Should throw DiskAlreadyInitializedError' {
                     {
@@ -846,10 +858,10 @@ try
                     } | Should Throw $errorRecord
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -868,7 +880,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Mbr } `
                     -Verifiable
 
@@ -883,7 +895,7 @@ try
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.DiskAlreadyInitializedError -f `
-                        'UniqueId',$script:mockedDisk0Mbr.UniqueId,$script:mockedDisk0Mbr.PartitionStyle)
+                        'UniqueId', $script:mockedDisk0Mbr.UniqueId, $script:mockedDisk0Mbr.PartitionStyle)
 
                 It 'Should throw DiskAlreadyInitializedError' {
                     {
@@ -895,10 +907,10 @@ try
                     } | Should Throw $errorRecord
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 0
@@ -917,7 +929,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -947,10 +959,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -969,7 +981,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1003,10 +1015,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -1025,7 +1037,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1060,10 +1072,10 @@ try
                     } | Should not throw
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Set-Disk -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Times 1
@@ -1091,7 +1103,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Offline } `
                     -Verifiable
 
@@ -1116,10 +1128,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Times 0
@@ -1134,7 +1146,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Offline } `
                     -Verifiable
 
@@ -1160,10 +1172,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Times 0
@@ -1178,7 +1190,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Readonly } `
                     -Verifiable
 
@@ -1203,10 +1215,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Times 0
@@ -1221,7 +1233,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0Raw } `
                     -Verifiable
 
@@ -1246,10 +1258,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 0
                     Assert-MockCalled -CommandName Get-Volume -Times 0
                     Assert-MockCalled -CommandName Get-CimInstance -Times 0
@@ -1264,7 +1276,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1300,10 +1312,10 @@ try
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1
@@ -1318,7 +1330,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1352,10 +1364,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1
@@ -1370,7 +1382,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1405,10 +1417,10 @@ try
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1
@@ -1423,7 +1435,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1458,10 +1470,10 @@ try
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1
@@ -1476,7 +1488,7 @@ try
                     -Verifiable
 
                 Mock `
-                    -CommandName Get-Disk `
+                    -CommandName Get-DiskByIdentifier `
                     -MockWith { $script:mockedDisk0 } `
                     -Verifiable
 
@@ -1513,10 +1525,10 @@ try
                     $script:result | Should Be $true
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled -CommandName Assert-AccessPathValid -Times 1
-                    Assert-MockCalled -CommandName Get-Disk -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Times 1
                     Assert-MockCalled -CommandName Get-Partition -Times 1
                     Assert-MockCalled -CommandName Get-Volume -Times 1
                     Assert-MockCalled -CommandName Get-CimInstance -Times 1

--- a/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
+++ b/Tests/Unit/MSFT_xDiskAccessPath.Tests.ps1
@@ -282,27 +282,27 @@ try
                     -AccessPath $script:testAccessPath `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Number)" {
+                It "Should return DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "AccessPath should be $($script:testAccessPath)" {
+                It "Should return AccessPath $($script:testAccessPath)" {
                     $resource.AccessPath | Should Be $script:testAccessPath
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should return Size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -350,27 +350,27 @@ try
                     -AccessPath $script:testAccessPath `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.UniqueId)" {
+                It "Should return DiskId $($script:mockedDisk0.UniqueId)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.UniqueId
                 }
 
-                It "AccessPath should be $($script:testAccessPath)" {
+                It "Should return AccessPath $($script:testAccessPath)" {
                     $resource.AccessPath | Should Be $script:testAccessPath
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should return Size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -418,27 +418,27 @@ try
                     -AccessPath $script:testAccessPath `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Guid)" {
+                It "Should return DiskId $($script:mockedDisk0.Guid)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Guid
                 }
 
-                It "AccessPath should be $($script:testAccessPath)" {
+                It "Should return AccessPath $($script:testAccessPath)" {
                     $resource.AccessPath | Should Be $script:testAccessPath
                 }
 
-                It "Size should be $($script:mockedPartition.Size)" {
+                It "Should return Size $($script:mockedPartition.Size)" {
                     $resource.Size | Should Be $script:mockedPartition.Size
                 }
 
-                It "FSLabel should be $($script:mockedVolume.FileSystemLabel)" {
+                It "Should return FSLabel $($script:mockedVolume.FileSystemLabel)" {
                     $resource.FSLabel | Should Be $script:mockedVolume.FileSystemLabel
                 }
 
-                It "AllocationUnitSize should be $($script:mockedCim.BlockSize)" {
+                It "Should return AllocationUnitSize $($script:mockedCim.BlockSize)" {
                     $resource.AllocationUnitSize | Should Be $script:mockedCim.BlockSize
                 }
 
-                It "FSFormat should be $($script:mockedVolume.FileSystem)" {
+                It "Should return FSFormat $($script:mockedVolume.FileSystem)" {
                     $resource.FSFormat | Should Be $script:mockedVolume.FileSystem
                 }
 
@@ -481,27 +481,27 @@ try
                     -AccessPath $script:testAccessPath `
                     -Verbose
 
-                It "DiskId should be $($script:mockedDisk0.Number)" {
+                It "Should return DiskId $($script:mockedDisk0.Number)" {
                     $resource.DiskId | Should Be $script:mockedDisk0.Number
                 }
 
-                It "AccessPath should be $($script:testAccessPath)" {
+                It "Should return AccessPath $($script:testAccessPath)" {
                     $resource.AccessPath | Should Be $script:testAccessPath
                 }
 
-                It "Size should be null" {
+                It "Should return Size null" {
                     $resource.Size | Should Be $null
                 }
 
-                It "FSLabel should be empty" {
+                It "Should return FSLabel empty" {
                     $resource.FSLabel | Should Be ''
                 }
 
-                It "AllocationUnitSize should be null" {
+                It "Should return AllocationUnitSize null" {
                     $resource.AllocationUnitSize | Should Be $null
                 }
 
-                It "FSFormat should be null" {
+                It "Should return FSFormat null" {
                     $resource.FSFormat | Should Be $null
                 }
 
@@ -561,13 +561,13 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -627,14 +627,14 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0Offline.UniqueId `
                             -DiskIdType 'UniqueId' `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -694,14 +694,14 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0Offline.Guid `
                             -DiskIdType 'Guid' `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -761,13 +761,13 @@ try
                 # mocks that should not be called
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0Readonly.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -830,13 +830,13 @@ try
 
                 # mocks that should not be called
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0OfflineRaw.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -896,13 +896,13 @@ try
                 # mocks that should not be called
                 Mock -CommandName Set-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0Raw.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -959,13 +959,13 @@ try
                 Mock -CommandName Set-Disk
                 Mock -CommandName Initialize-Disk
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1165,13 +1165,13 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Add-PartitionAccessPath
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1222,14 +1222,14 @@ try
                 Mock -CommandName New-Partition
                 Mock -CommandName Format-Volume
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -Size $script:mockedPartitionSize `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1281,14 +1281,14 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Add-PartitionAccessPath
 
-                It 'Should not throw' {
+                It 'Should not throw an exception' {
                     {
                         Set-targetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 It 'Should call the correct mocks' {
@@ -1335,17 +1335,17 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Number `
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1380,7 +1380,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.UniqueId `
@@ -1388,10 +1388,10 @@ try
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1426,7 +1426,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Offline.Guid `
@@ -1434,10 +1434,10 @@ try
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1472,17 +1472,17 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Readonly.Number `
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1517,17 +1517,17 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0Raw.Number `
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4096 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1572,7 +1572,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1580,10 +1580,10 @@ try
                             -AllocationUnitSize 4096 `
                             -Size 124 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be true' {
+                It 'Should return true' {
                     $script:result | Should Be $true
                 }
 
@@ -1626,18 +1626,18 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -AllocationUnitSize 4097 `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
                 # skipped due to:  https://github.com/PowerShell/xStorage/issues/22
-                It 'result should be false' -skip {
+                It 'Should return false' -skip {
                     $script:result | Should Be $false
                 }
 
@@ -1682,17 +1682,17 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -FSFormat 'ReFS' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be true' {
+                It 'Should return true' {
                     $script:result | Should Be $true
                 }
 
@@ -1737,17 +1737,17 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
                             -AccessPath $script:testAccessPath `
                             -FSLabel 'NewLabel' `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
@@ -1792,7 +1792,7 @@ try
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource `
                             -DiskId $script:mockedDisk0.Number `
@@ -1801,10 +1801,10 @@ try
                             -Size $script:mockedPartition.Size `
                             -FSFormat $script:mockedVolume.FileSystem `
                             -Verbose
-                    } | Should not throw
+                    } | Should Not Throw
                 }
 
-                It 'result should be true' {
+                It 'Should return true' {
                     $script:result | Should Be $true
                 }
 

--- a/Tests/Unit/MSFT_xMountImage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMountImage.Tests.ps1
@@ -438,7 +438,7 @@ try
                 Mock -CommandName Mount-DiskImageToLetter
                 Mock -CommandName Dismount-DiskImage
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageISOPath `
@@ -472,7 +472,7 @@ try
                     -CommandName Dismount-DiskImage `
                     -Verifiable
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageISOPath `
@@ -505,7 +505,7 @@ try
                 # Mocks that should not be called
                 Mock -CommandName Dismount-DiskImage
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageISOPath `
@@ -538,7 +538,7 @@ try
                 # Mocks that should not be called
                 Mock -CommandName Mount-DiskImageToLetter
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageISOPath `
@@ -567,7 +567,7 @@ try
                 Mock -CommandName Dismount-DiskImage
                 Mock -CommandName Mount-DiskImageToLetter
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageISOPath `
@@ -600,7 +600,7 @@ try
                     -CommandName Dismount-DiskImage `
                     -Verifiable
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Set-TargetResource `
                             -ImagePath $script:DiskImageVHDXPath `
@@ -813,7 +813,7 @@ try
             }
 
             Context 'Ensure is Absent, nothing else passed' {
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Test-ParameterValid `
                             -ImagePath $script:DiskImageISOPath `
@@ -862,7 +862,7 @@ try
             }
 
             Context 'ImagePath passed and found, ensure is Present, DriveLetter set' {
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     Mock `
                         -CommandName Test-Path `
                         -MockWith { $true }
@@ -948,7 +948,7 @@ try
                 Mock -CommandName Get-CimInstance
                 Mock -CommandName Set-CimInstance
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Mount-DiskImageToLetter `
                             -ImagePath $script:DiskImageISOPath `
@@ -998,7 +998,7 @@ try
                 Mock -CommandName Get-Disk
                 Mock -CommandName Get-Partition
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Mount-DiskImageToLetter `
                             -ImagePath $script:DiskImageISOPath `
@@ -1049,7 +1049,7 @@ try
                 Mock -CommandName Get-CimInstance
                 Mock -CommandName Set-CimInstance
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Mount-DiskImageToLetter `
                             -ImagePath $script:DiskImageVHDxPath `
@@ -1105,7 +1105,7 @@ try
                     -CommandName Set-CimInstance `
                     -Verifiable
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     {
                         Mount-DiskImageToLetter `
                             -ImagePath $script:DiskImageVHDXPath `

--- a/Tests/Unit/MSFT_xWaitForDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForDisk.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xStorage'
-$script:DSCResourceName    = 'MSFT_xWaitForDisk'
+$script:DSCModuleName = 'xStorage'
+$script:DSCResourceName = 'MSFT_xWaitForDisk'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
@@ -7,9 +7,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xStorage'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -28,31 +28,42 @@ try
     # (non-exported) code of a Script Module.
     InModuleScope $script:DSCResourceName {
         #region Pester Test Initialization
-        $script:testDiskUniqueId = 'TESTDISKUNIQUEID'
+        $testDiskNumber = 1
+        $testDiskUniqueId = 'TESTDISKUNIQUEID'
+        $testDiskGptGuid = [guid]::NewGuid()
 
         $mockedDisk0 = [pscustomobject] @{
-            Number = 0
-            UniqueId = $script:testDiskUniqueId
+            Number       = $testDiskNumber
+            UniqueId     = $testDiskUniqueId
+            Guid         = $testDiskGptGuid
             FriendlyName = 'Test Disk'
         }
 
         $disk0ParametersByNumber = @{
-            DiskId = 0
+            DiskId           = $testDiskNumber
+            DiskIdType       = 'Number'
             RetryIntervalSec = 5
-            RetryCount = 20
+            RetryCount       = 20
         }
 
         $disk0ParametersByUniqueId = @{
-            DiskId = $script:testDiskUniqueId
-            DiskIdType = 'UniqueId'
+            DiskId           = $testDiskUniqueId
+            DiskIdType       = 'UniqueId'
             RetryIntervalSec = 5
-            RetryCount = 20
+            RetryCount       = 20
+        }
+
+        $disk0ParametersByGptGuid = @{
+            DiskId           = $testDiskGptGuid
+            DiskIdType       = 'Guid'
+            RetryIntervalSec = 5
+            RetryCount       = 20
         }
         #endregion
 
         #region Function Get-TargetResource
         Describe "MSFT_xWaitForDisk\Get-TargetResource" {
-            Context 'disk is specified by Number' {
+            Context 'Disk is specified by Number' {
                 $script:result = $null
 
                 It 'Should Not Throw' {
@@ -61,24 +72,24 @@ try
                     } | Should Not Throw
                 }
 
-                It "should return a DiskId of $($disk0ParametersByNumber.DiskId)" {
+                It "Should return a DiskId of $($disk0ParametersByNumber.DiskId)" {
                     $script:result.DiskId | Should Be $disk0ParametersByNumber.DiskId
                 }
 
-                It "should return a DiskIdType of Number" {
+                It 'Should return a DiskIdType of Number' {
                     $script:result.DiskIdType | Should Be 'Number'
                 }
 
-                It "should return a RetryIntervalSec of $($disk0ParametersByNumber.RetryIntervalSec)" {
+                It "Should return a RetryIntervalSec of $($disk0ParametersByNumber.RetryIntervalSec)" {
                     $script:result.RetryIntervalSec | Should Be $disk0ParametersByNumber.RetryIntervalSec
                 }
 
-                It "should return a RetryIntervalSec of $($disk0ParametersByNumber.RetryCount)" {
+                It "Should return a RetryIntervalSec of $($disk0ParametersByNumber.RetryCount)" {
                     $script:result.RetryCount | Should Be $disk0ParametersByNumber.RetryCount
                 }
             }
 
-            Context 'disk is specified by Unique Id' {
+            Context 'Disk is specified by Unique Id' {
                 $script:result = $null
 
                 It 'Should Not Throw' {
@@ -87,20 +98,46 @@ try
                     } | Should Not Throw
                 }
 
-                It "should return a DiskId of $($disk0ParametersByUniqueId.DiskId)" {
+                It "Should return a DiskId of $($disk0ParametersByUniqueId.DiskId)" {
                     $script:result.DiskId | Should Be $disk0ParametersByUniqueId.DiskId
                 }
 
-                It "should return a DiskIdType of UniqueId" {
+                It "Should return a DiskIdType of UniqueId" {
                     $script:result.DiskIdType | Should Be 'UniqueId'
                 }
 
-                It "should return a RetryIntervalSec of $($disk0ParametersByUniqueId.RetryIntervalSec)" {
+                It "Should return a RetryIntervalSec of $($disk0ParametersByUniqueId.RetryIntervalSec)" {
                     $script:result.RetryIntervalSec | Should Be $disk0ParametersByUniqueId.RetryIntervalSec
                 }
 
-                It "should return a RetryIntervalSec of $($disk0ParametersByUniqueId.RetryCount)" {
+                It "Should return a RetryIntervalSec of $($disk0ParametersByUniqueId.RetryCount)" {
                     $script:result.RetryCount | Should Be $disk0ParametersByUniqueId.RetryCount
+                }
+            }
+
+            Context 'Disk is specified by Guid' {
+                $script:result = $null
+
+                It 'Should Not Throw' {
+                    {
+                        $script:result = Get-TargetResource @disk0ParametersByGptGuid -Verbose
+                    } | Should Not Throw
+                }
+
+                It "Should return a DiskId of $($disk0ParametersByGptGuid.DiskId)" {
+                    $script:result.DiskId | Should Be $disk0ParametersByGptGuid.DiskId
+                }
+
+                It "Should return a DiskIdType of Guid" {
+                    $script:result.DiskIdType | Should Be 'Guid'
+                }
+
+                It "Should return a RetryIntervalSec of $($disk0ParametersByGptGuid.RetryIntervalSec)" {
+                    $script:result.RetryIntervalSec | Should Be $disk0ParametersByGptGuid.RetryIntervalSec
+                }
+
+                It "Should return a RetryIntervalSec of $($disk0ParametersByGptGuid.RetryCount)" {
+                    $script:result.RetryCount | Should Be $disk0ParametersByGptGuid.RetryCount
                 }
             }
         }
@@ -110,11 +147,11 @@ try
         Describe 'MSFT_xWaitForDisk\Set-TargetResource' {
             Mock -CommandName Start-Sleep
 
-            Context 'disk number 0 is ready' {
+            Context "Disk Number $testDiskNumber is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $Number[0] -eq 0 } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' } `
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
@@ -122,18 +159,19 @@ try
                     { Set-targetResource @disk0ParametersByNumber -Verbose } | Should Not throw
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Start-Sleep -Times 0
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $Number[0] -eq 0 } -Times 1
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' }
                 }
             }
 
-            Context "disk with unique id '$script:testDiskUniqueId' is ready" {
+            Context "Disk with Unique Id '$testDiskUniqueId' is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' } `
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
@@ -141,56 +179,103 @@ try
                     { Set-targetResource @disk0ParametersByUniqueId -Verbose } | Should Not throw
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Start-Sleep -Times 0
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } -Times 1
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' }
                 }
             }
 
-            Context 'disk number 0 does not become ready' {
+            Context "Disk with Guid '$testDiskGptGuid' is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $Number[0] -eq 0 } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' } `
+                    -MockWith { return $mockedDisk0 } `
+                    -Verifiable
+
+                It 'Should Not Throw' {
+                    { Set-targetResource @disk0ParametersByGptGuid -Verbose } | Should Not throw
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' }
+                }
+            }
+
+            Context "Disk Number $testDiskNumber does not become ready" {
+                # verifiable (Should Be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' } `
                     -MockWith { } `
                     -Verifiable
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message $($LocalizedData.DiskNotFoundAfterError `
-                        -f 'Number',$disk0ParametersByNumber.DiskId,$disk0ParametersByNumber.RetryCount)
+                        -f 'Number', $disk0ParametersByNumber.DiskId, $disk0ParametersByNumber.RetryCount)
 
-                It 'should throw DiskNotFoundAfterError' {
+                It 'Should throw DiskNotFoundAfterError' {
                     { Set-targetResource @disk0ParametersByNumber -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Start-Sleep -Times $disk0ParametersByNumber.RetryCount
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $Number[0] -eq 0 } -Times 1
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times $disk0ParametersByNumber.RetryCount
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times $disk0ParametersByNumber.RetryCount `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' } `
                 }
             }
 
-            Context "disk with unique id '$script:testDiskUniqueId' does not become ready" {
+            Context "Disk with Unique Id '$testDiskUniqueId' does not become ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' } `
                     -MockWith { } `
                     -Verifiable
 
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message $($LocalizedData.DiskNotFoundAfterError `
-                        -f 'UniqueId',$disk0ParametersByUniqueId.DiskId,$disk0ParametersByUniqueId.RetryCount)
+                        -f 'UniqueId', $disk0ParametersByUniqueId.DiskId, $disk0ParametersByUniqueId.RetryCount)
 
-                It 'should throw DiskNotFoundAfterError' {
+                It 'Should throw DiskNotFoundAfterError' {
                     { Set-targetResource @disk0ParametersByUniqueId -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Start-Sleep -Times $disk0ParametersByUniqueId.RetryCount
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } -Times 1
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times $disk0ParametersByUniqueId.RetryCount
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times $disk0ParametersByNumber.RetryCount `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' } `
+                }
+            }
+
+            Context "Disk with Guid '$testDiskGptGuid' does not become ready" {
+                # verifiable (Should Be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' } `
+                    -MockWith { } `
+                    -Verifiable
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message $($LocalizedData.DiskNotFoundAfterError `
+                        -f 'Guid', $disk0ParametersByGptGuid.DiskId, $disk0ParametersByGptGuid.RetryCount)
+
+                It 'Should throw DiskNotFoundAfterError' {
+                    { Set-targetResource @disk0ParametersByGptGuid -Verbose } | Should Throw $errorRecord
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times $disk0ParametersByGptGuid.RetryCount
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times $disk0ParametersByGptGuid.RetryCount `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' }
                 }
             }
         }
@@ -198,11 +283,11 @@ try
 
         #region Function Test-TargetResource
         Describe 'MSFT_xWaitForDisk\Test-TargetResource' {
-            Context 'disk number 0 is ready' {
+            Context "Disk Number $testDiskNumber is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $Number[0] -eq 0 } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' } `
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
@@ -214,21 +299,22 @@ try
                     } | Should Not Throw
                 }
 
-                It "should return a result of true" {
+                It 'Should return a result of true' {
                     $script:result | Should Be $true
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $Number[0] -eq 0 } -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' }
                 }
             }
 
-            Context "disk with unique id '$script:testDiskUniqueId' is ready" {
+            Context "Disk with Unique Id '$testDiskUniqueId' is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' } `
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
@@ -240,65 +326,122 @@ try
                     } | Should Not Throw
                 }
 
-                It "should return a result of true" {
+                It 'Should return a result of true' {
                     $script:result | Should Be $true
                 }
 
-                It 'should call the correct mocks' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' }
                 }
             }
 
-            Context 'disk number 0 does not become ready' {
+            Context "Disk with Guid '$testDiskGptGuid' is ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $Number[0] -eq 0 } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' } `
+                    -MockWith { return $mockedDisk0 } `
+                    -Verifiable
+
+                $script:result = $null
+
+                It 'Should Not Throw' {
+                    {
+                        $script:result = Test-TargetResource @disk0ParametersByGptGuid -Verbose
+                    } | Should Not Throw
+                }
+
+                It 'Should return a result of true' {
+                    $script:result | Should Be $true
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' }
+                }
+            }
+
+            Context "Disk Number $testDiskNumber does not become ready" {
+                # verifiable (Should Be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' } `
                     -MockWith { } `
                     -Verifiable
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByNumber -Verbose
                     } | Should Not Throw
                 }
 
-                It 'result Should Be false' {
+                It 'Result Should Be false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $Number[0] -eq 0 } -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByNumber.DiskId -and $DiskIdType -eq 'Number' }
                 }
             }
 
-            Context "disk with unique id '$script:testDiskUniqueId' does not become ready" {
+            Context "Disk with Unique Id '$testDiskUniqueId' does not become ready" {
                 # verifiable (Should Be called) mocks
                 Mock `
-                    -CommandName Get-Disk `
-                    -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' } `
                     -MockWith { } `
                     -Verifiable
 
                 $script:result = $null
 
-                It 'calling test Should Not Throw' {
+                It 'Should Not Throw' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByUniqueId -Verbose
                     } | Should Not Throw
                 }
 
-                It 'result Should Be false' {
+                It 'Should return false' {
                     $script:result | Should Be $false
                 }
 
-                It 'the correct mocks were called' {
+                It 'Should call the correct mocks' {
                     Assert-VerifiableMocks
-                    Assert-MockCalled -CommandName Get-Disk -ParameterFilter { $UniqueId -eq $script:testDiskUniqueId } -Times 1
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByUniqueId.DiskId -and $DiskIdType -eq 'UniqueId' }
+                }
+            }
+
+            Context "Disk with Guid '$testDiskGptGuid' does not become ready" {
+                # verifiable (Should Be called) mocks
+                Mock `
+                    -CommandName Get-DiskByIdentifier `
+                    -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' } `
+                    -MockWith { } `
+                    -Verifiable
+
+                $script:result = $null
+
+                It 'Should Not Throw' {
+                    {
+                        $script:result = Test-TargetResource @disk0ParametersByGptGuid -Verbose
+                    } | Should Not Throw
+                }
+
+                It 'Should return false' {
+                    $script:result | Should Be $false
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+                    Assert-MockCalled -CommandName Get-DiskByIdentifier -Exactly -Times 1 `
+                        -ParameterFilter { $DiskId -eq $disk0ParametersByGptGuid.DiskId -and $DiskIdType -eq 'Guid' }
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWaitForDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForDisk.Tests.ps1
@@ -66,7 +66,7 @@ try
             Context 'Disk is specified by Number' {
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Get-TargetResource @disk0ParametersByNumber -Verbose
                     } | Should Not Throw
@@ -92,7 +92,7 @@ try
             Context 'Disk is specified by Unique Id' {
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Get-TargetResource @disk0ParametersByUniqueId -Verbose
                     } | Should Not Throw
@@ -118,7 +118,7 @@ try
             Context 'Disk is specified by Guid' {
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Get-TargetResource @disk0ParametersByGptGuid -Verbose
                     } | Should Not Throw
@@ -155,7 +155,7 @@ try
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     { Set-targetResource @disk0ParametersByNumber -Verbose } | Should Not throw
                 }
 
@@ -175,7 +175,7 @@ try
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     { Set-targetResource @disk0ParametersByUniqueId -Verbose } | Should Not throw
                 }
 
@@ -195,7 +195,7 @@ try
                     -MockWith { return $mockedDisk0 } `
                     -Verifiable
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     { Set-targetResource @disk0ParametersByGptGuid -Verbose } | Should Not throw
                 }
 
@@ -293,7 +293,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByNumber -Verbose
                     } | Should Not Throw
@@ -320,7 +320,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByUniqueId -Verbose
                     } | Should Not Throw
@@ -347,7 +347,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByGptGuid -Verbose
                     } | Should Not Throw
@@ -374,7 +374,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByNumber -Verbose
                     } | Should Not Throw
@@ -401,7 +401,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByUniqueId -Verbose
                     } | Should Not Throw
@@ -428,7 +428,7 @@ try
 
                 $script:result = $null
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     {
                         $script:result = Test-TargetResource @disk0ParametersByGptGuid -Verbose
                     } | Should Not Throw

--- a/Tests/Unit/MSFT_xWaitForVolume.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForVolume.Tests.ps1
@@ -68,7 +68,7 @@ try
                 # verifiable (Should Be called) mocks
                 Mock Get-Volume -MockWith { return $mockedDriveC } -Verifiable
 
-                It 'Should Not Throw' {
+                It 'Should not throw an exception' {
                     { Set-targetResource @driveCParameters -Verbose } | Should Not throw
                 }
 

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -181,7 +181,7 @@ try
                     (Get-DiskByIdentifier -DiskId $testDiskNumber).Number | Should Be $testDiskNumber
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `
@@ -203,7 +203,7 @@ try
                     Get-DiskByIdentifier -DiskId $testDiskNumber | Should BeNullOrEmpty
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `
@@ -226,7 +226,7 @@ try
                     (Get-DiskByIdentifier -DiskId $testDiskUniqueId -DiskIdType 'UniqueId').UniqueId | Should Be $testDiskUniqueId
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `
@@ -248,7 +248,7 @@ try
                     Get-DiskByIdentifier -DiskId $testDiskUniqueId -DiskIdType 'UniqueId' | Should BeNullOrEmpty
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `
@@ -270,7 +270,7 @@ try
                     (Get-DiskByIdentifier -DiskId $testDiskGuid -DiskIdType 'Guid').Guid | Should Be $testDiskGuid
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `
@@ -290,7 +290,7 @@ try
                     Get-DiskByIdentifier -DiskId $testDiskGuid -DiskIdType 'Guid' | Should BeNullOrEmpty
                 }
 
-                It 'Should call exepced mocks' {
+                It 'Should call expected mocks' {
                     Assert-VerifiableMocks
                     Assert-MockCalled `
                         -CommandName Get-Disk `


### PR DESCRIPTION
This PR adds support for specifying the disk to work with using the Disk GUID. This is a unique value that is only assigned to the disk once it is initialized (a partition table is created). It will work with either MBR or GPT partition formats.

I've applied auto-formatting on any files I touched.

Tagging @Zuldan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/107)
<!-- Reviewable:end -->
