### PR TITLE
Updated License Year and Set VSCode Custom Formatting present - Fixes #111

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   - CONTRIBUTING.md
   - ISSUE_TEMPLATE.md
   - PULL_REQUEST_TEMPLATE.md
+- Changed license year to 2017 and set company name to Microsoft
+  Corporation in LICENSE.MD and module manifest - See [Issue 111](https://github.com/PowerShell/xStorage/issues/111).
+- Set Visual Studio Code setting "powershell.codeFormatting.preset" to
+  "custom" - See [Issue 108](https://github.com/PowerShell/xStorage/issues/108)
 
 ## 3.2.0.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Michael Greene
+Copyright (c) 2017 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Modules/xStorage/xStorage.psd1
+++ b/Modules/xStorage/xStorage.psd1
@@ -22,7 +22,7 @@ Author = 'PowerShell DSC'
 CompanyName = 'Microsoft Corporation'
 
 # Copyright statement for this module
-Copyright = '2015'
+Copyright = '2017'
 
 # Description of the functionality provided by this module
 Description = 'This module contains all resources related to the PowerShell Storage module, or pertaining to disk management.'


### PR DESCRIPTION
**Pull Request (PR) description**

1. Updates License Year to 2017 and sets Company Name to Microsoft Corporation in LICENSE.MD and manifest.
1. Sets PowerShell Formatting preset to custom for VSCode.

**This Pull Request (PR) fixes the following issues:**
Fixes #111 
Fixes #108 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - would you mind reviewing if you get a moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/114)
<!-- Reviewable:end -->
