### PR TITLE
Fix when max size used and disk partitioned and formatted but not mounted - Fixes #103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- xDisk:
+  - Removed duplicate integration tests for Guid Disk Id type.
+
 ## 3.3.0.0
 
 - Opted into common tests for Module and Script files - See [Issue 115](https://github.com/PowerShell/xStorage/issues/115).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
   - Removed duplicate integration tests for Guid Disk Id type.
   - Added new contexts to integration tests improve clarity.
   - Fix bug when size not specified and disk partitioned and
-    formatted but not mounted - See [Issue 103](https://github.com/PowerShell/xStorage/issues/103).
+    formatted but not assigned drive letter - See [Issue 103](https://github.com/PowerShell/xStorage/issues/103).
 - xDiskAccessPath:
   - Added new contexts to integration tests improve clarity.
+  - Fix bug when size not specified and disk partitioned and
+    formatted but not assigned to path - See [Issue 103](https://github.com/PowerShell/xStorage/issues/103).
 
 ## 3.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - xDisk:
   - Removed duplicate integration tests for Guid Disk Id type.
+  - Added new contexts to integration tests improve clarity.
+  - Fix bug when size not specified and disk partitioned and
+    formatted but not mounted - See [Issue 103](https://github.com/PowerShell/xStorage/issues/103).
+- xDiskAccessPath:
+  - Added new contexts to integration tests improve clarity.
 
 ## 3.3.0.0
 

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -66,7 +66,7 @@ function Get-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -184,7 +184,7 @@ function Set-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -352,7 +352,7 @@ function Set-TargetResource
                     matching the file system type that is not assigned to a drive letter.
                 #>
                 Write-Verbose -Message ($localizedData.MatchingPartitionNoSizeMessage -f `
-                    $DiskIdType, $DiskId)
+                        $DiskIdType, $DiskId)
 
                 $searchPartitions = $partition | Where-Object -FilterScript {
                     $_.Type -eq 'Basic' -and -not [System.Char]::IsLetter($_.DriveLetter)
@@ -364,7 +364,7 @@ function Set-TargetResource
                 {
                     # Look for the volume in the partition.
                     Write-Verbose -Message ($localizedData.SearchForVolumeMessage -f `
-                        $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
+                            $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
 
                     $searchVolumes = $searchPartition | Get-Volume
 
@@ -381,7 +381,7 @@ function Set-TargetResource
                         $partition = $searchPartition
 
                         Write-Verbose -Message ($localizedData.VolumeFoundMessage -f `
-                            $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
+                                $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
 
                         break
                     } # if
@@ -649,7 +649,7 @@ function Test-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/MSFT_xDisk.psm1
@@ -329,7 +329,7 @@ function Set-TargetResource
             {
                 # Find the first basic partition matching the size
                 $partition = $partition |
-                    Where-Object -Filter { $_.Type -eq 'Basic' -and $_.Size -eq $Size } |
+                    Where-Object -FilterScript { $_.Type -eq 'Basic' -and $_.Size -eq $Size } |
                     Select-Object -First 1
 
                 if ($partition)
@@ -354,7 +354,10 @@ function Set-TargetResource
                 Write-Verbose -Message ($localizedData.MatchingPartitionNoSizeMessage -f `
                     $DiskIdType, $DiskId)
 
-                $searchPartitions = $partition | Where-Object -Filter { $_.Type -eq 'Basic' }
+                $searchPartitions = $partition | Where-Object -FilterScript {
+                    $_.Type -eq 'Basic' -and -not [System.Char]::IsLetter($_.DriveLetter)
+                }
+
                 $partition = $null
 
                 foreach ($searchPartition in $searchPartitions)
@@ -366,8 +369,7 @@ function Set-TargetResource
                     $searchVolumes = $searchPartition | Get-Volume
 
                     $volumeMatch = $searchVolumes | Where-Object -FilterScript {
-                        ($_.FileSystem -eq $FSFormat) -and `
-                        ([System.String]::IsNullOrEmpty($_.DriveLetter))
+                        $_.FileSystem -eq $FSFormat
                     }
 
                     if ($volumeMatch)

--- a/Modules/xStorage/DSCResources/MSFT_xDisk/en-us/MSFT_xDisk.strings.psd1
+++ b/Modules/xStorage/DSCResources/MSFT_xDisk/en-us/MSFT_xDisk.strings.psd1
@@ -26,6 +26,9 @@
     DriveLabelMismatch = Volume assigned to drive {0} label '{1}' does not match expected label '{2}'.
     PartitionAlreadyAssignedMessage = Partition '{1}' is already assigned as drive {0}.
     MatchingPartitionNotFoundMessage = Disk with {0} '{1}' already contains partitions, but none match required size.
+    MatchingPartitionNoSizeMessage = Disk with {0} '{1}' already contains partitions, but size parameter is not specified.
+    SearchForVolumeMessage = Searching for {3} volume with no drive letter on partition '{2}' disk with {0} '{1}'.
+    VolumeFoundMessage = Found {3} volume with no drive letter on partition '{2}' disk with {0} '{1}'.
     MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains partitions, and partition '{2}' matches required size.
     DriveNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to drive letter '{2}'.
     ClearingDisk = Clearing disk with {0} '{1}' of all existing partitions and volumes.

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/MSFT_xDiskAccessPath.psm1
@@ -7,13 +7,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
-                                                     -ChildPath 'StorageDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+            -ChildPath 'StorageDsc.Common.psm1'))
 
 # Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
-                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+            -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -60,7 +60,7 @@ function Get-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -77,14 +77,14 @@ function Get-TargetResource
         $AllocationUnitSize,
 
         [Parameter()]
-        [ValidateSet('NTFS','ReFS')]
+        [ValidateSet('NTFS', 'ReFS')]
         [System.String]
         $FSFormat = 'NTFS'
     )
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($localizedData.GettingDiskMessage -f $DiskIdType,$DiskId,$AccessPath)
+            $($localizedData.GettingDiskMessage -f $DiskIdType, $DiskId, $AccessPath)
         ) -join '' )
 
     # Validate the AccessPath parameter adding a trailing slash
@@ -100,7 +100,7 @@ function Get-TargetResource
 
     # Check if the disk has an existing partition assigned to the access path
     $assignedPartition = $partition |
-            Where-Object -Property AccessPaths -Contains -Value $AccessPath
+        Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
     $volume = $assignedPartition | Get-Volume
 
@@ -108,20 +108,20 @@ function Get-TargetResource
     $FSLabel = $volume.FileSystemLabel
 
     # Prepare the AccessPath used in the CIM query (replaces '\' with '\\')
-    $queryAccessPath = $AccessPath -replace '\\','\\'
+    $queryAccessPath = $AccessPath -replace '\\', '\\'
 
     $blockSize = (Get-CimInstance `
-        -Query "SELECT BlockSize from Win32_Volume WHERE Name = '$queryAccessPath'" `
-        -ErrorAction SilentlyContinue).BlockSize
+            -Query "SELECT BlockSize from Win32_Volume WHERE Name = '$queryAccessPath'" `
+            -ErrorAction SilentlyContinue).BlockSize
 
     $returnValue = @{
-        DiskId = $DiskId
-        DiskIdType = $DiskIdType
-        AccessPath = $AccessPath
-        Size = $assignedPartition.Size
-        FSLabel = $FSLabel
+        DiskId             = $DiskId
+        DiskIdType         = $DiskIdType
+        AccessPath         = $AccessPath
+        Size               = $assignedPartition.Size
+        FSLabel            = $FSLabel
         AllocationUnitSize = $blockSize
-        FSFormat = $fileSystem
+        FSFormat           = $fileSystem
     }
     $returnValue
 } # Get-TargetResource
@@ -167,7 +167,7 @@ function Set-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -184,14 +184,14 @@ function Set-TargetResource
         $AllocationUnitSize,
 
         [Parameter()]
-        [ValidateSet('NTFS','ReFS')]
+        [ValidateSet('NTFS', 'ReFS')]
         [System.String]
         $FSFormat = 'NTFS'
     )
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($localizedData.SettingDiskMessage -f $DiskIdType,$DiskId,$AccessPath)
+            $($localizedData.SettingDiskMessage -f $DiskIdType, $DiskId, $AccessPath)
         ) -join '' )
 
     # Validate the AccessPath parameter adding a trailing slash
@@ -207,7 +207,7 @@ function Set-TargetResource
         # Disk is offline, so bring it online
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.SetDiskOnlineMessage -f $DiskIdType,$DiskId)
+                $($localizedData.SetDiskOnlineMessage -f $DiskIdType, $DiskId)
             ) -join '' )
 
         $disk | Set-Disk -IsOffline $false
@@ -218,7 +218,7 @@ function Set-TargetResource
         # Disk is read-only, so make it read/write
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.SetDiskReadWriteMessage -f $DiskIdType,$DiskId)
+                $($localizedData.SetDiskReadWriteMessage -f $DiskIdType, $DiskId)
             ) -join '' )
 
         $disk | Set-Disk -IsReadOnly $false
@@ -226,7 +226,7 @@ function Set-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($localizedData.CheckingDiskPartitionStyleMessage -f $DiskIdType,$DiskId)
+            $($localizedData.CheckingDiskPartitionStyleMessage -f $DiskIdType, $DiskId)
         ) -join '' )
 
     switch ($disk.PartitionStyle)
@@ -236,7 +236,7 @@ function Set-TargetResource
             # The disk partition table is not yet initialized, so initialize it with GPT
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($localizedData.InitializingDiskMessage -f $DiskIdType,$DiskId)
+                    $($localizedData.InitializingDiskMessage -f $DiskIdType, $DiskId)
                 ) -join '' )
 
             $disk | Initialize-Disk `
@@ -249,7 +249,7 @@ function Set-TargetResource
             # The disk partition is already initialized with GPT.
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
-                    $($localizedData.DiskAlreadyInitializedMessage -f $DiskIdType,$DiskId)
+                    $($localizedData.DiskAlreadyInitializedMessage -f $DiskIdType, $DiskId)
                 ) -join '' )
             break
         } # 'GPT'
@@ -259,7 +259,7 @@ function Set-TargetResource
             # This disk is initialized but not as GPT - so raise an exception.
             New-InvalidOperationException `
                 -Message ($localizedData.DiskAlreadyInitializedError -f `
-                    $DiskIdType,$DiskId,$Disk.PartitionStyle)
+                    $DiskIdType, $DiskId, $Disk.PartitionStyle)
         } # default
     } # switch
 
@@ -268,14 +268,14 @@ function Set-TargetResource
 
     # Check if the disk has an existing partition assigned to the access path
     $assignedPartition = $partition |
-            Where-Object -Property AccessPaths -Contains -Value $AccessPath
+        Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
     if ($null -eq $assignedPartition)
     {
         # There is no partiton with this access path
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.AccessPathNotFoundOnPartitionMessage -f $DiskIdType,$DiskId,$AccessPath)
+                $($localizedData.AccessPathNotFoundOnPartitionMessage -f $DiskIdType, $DiskId, $AccessPath)
             ) -join '' )
 
         # Are there any partitions defined on this disk?
@@ -293,19 +293,56 @@ function Set-TargetResource
                 {
                     # A partition matching the required size was found
                     Write-Verbose -Message ($localizedData.MatchingPartitionFoundMessage -f `
-                        $DiskIdType,$DiskId,$partition.PartitionNumber)
+                            $DiskIdType, $DiskId, $partition.PartitionNumber)
                 }
                 else
                 {
                     # A partition matching the required size was not found
                     Write-Verbose -Message ($localizedData.MatchingPartitionNotFoundMessage -f `
-                        $DiskIdType,$DiskId)
+                            $DiskIdType, $DiskId)
                 } # if
             }
             else
             {
-                # No size specified so no partition can be matched
+                <#
+                    No size specified, so see if there is a partition that has a volume
+                    matching the file system type that is not assigned to an access path.
+                #>
+                Write-Verbose -Message ($localizedData.MatchingPartitionNoSizeMessage -f `
+                        $DiskIdType, $DiskId)
+
+                $searchPartitions = $partition | Where-Object -FilterScript {
+                    $_.Type -eq 'Basic' -and -not (Test-AccessPathAssignedToLocal -AccessPath $_.AccessPaths)
+                }
+
                 $partition = $null
+
+                foreach ($searchPartition in $searchPartitions)
+                {
+                    # Look for the volume in the partition.
+                    Write-Verbose -Message ($localizedData.SearchForVolumeMessage -f `
+                            $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
+
+                    $searchVolumes = $searchPartition | Get-Volume
+
+                    $volumeMatch = $searchVolumes | Where-Object -FilterScript {
+                        $_.FileSystem -eq $FSFormat
+                    }
+
+                    if ($volumeMatch)
+                    {
+                        <#
+                            Found a partition with a volume that matches file system
+                            type and not assigned an access path.
+                        #>
+                        $partition = $searchPartition
+
+                        Write-Verbose -Message ($localizedData.VolumeFoundMessage -f `
+                                $DiskIdType, $DiskId, $searchPartition.PartitionNumber, $FSFormat)
+
+                        break
+                    } # if
+                } # foreach
             } # if
         } # if
 
@@ -321,7 +358,7 @@ function Set-TargetResource
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
                         $($localizedData.CreatingPartitionMessage `
-                            -f $DiskIdType,$DiskId,"$($Size/1KB) KB")
+                                -f $DiskIdType, $DiskId, "$($Size/1KB) KB")
                     ) -join '' )
                 $partitionParams['Size'] = $Size
             }
@@ -331,7 +368,7 @@ function Set-TargetResource
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
                         $($localizedData.CreatingPartitionMessage `
-                            -f $DiskIdType,$DiskId,'all free space')
+                                -f $DiskIdType, $DiskId, 'all free space')
                     ) -join '' )
                 $partitionParams['UseMaximumSize'] = $true
             } # if
@@ -347,7 +384,7 @@ function Set-TargetResource
             while ($partition.IsReadOnly -and (Get-Date) -lt $timeout)
             {
                 Write-Verbose -Message ($localizedData.NewPartitionIsReadOnlyMessage -f `
-                    $DiskIdType,$DiskId,$partition.PartitionNumber)
+                        $DiskIdType, $DiskId, $partition.PartitionNumber)
 
                 Start-Sleep -Seconds 1
 
@@ -361,7 +398,7 @@ function Set-TargetResource
             # The partition is still readonly - throw an exception
             New-InvalidOperationException `
                 -Message ($localizedData.NewParitionIsReadOnlyError -f `
-                    $DiskIdType,$DiskId,$partition.PartitionNumber)
+                    $DiskIdType, $DiskId, $partition.PartitionNumber)
         } # if
 
         $assignAccessPath = $true
@@ -372,7 +409,7 @@ function Set-TargetResource
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
                 $($localizedData.PartitionAlreadyAssignedMessage -f `
-                    $AccessPath,$partition.PartitionNumber)
+                        $AccessPath, $partition.PartitionNumber)
             ) -join '' )
 
         $assignAccessPath = $false
@@ -387,7 +424,7 @@ function Set-TargetResource
         # The volume is not formatted
         $volParams = @{
             FileSystem = $FSFormat
-            Confirm = $false
+            Confirm    = $false
         }
 
         if ($FSLabel)
@@ -424,7 +461,7 @@ function Set-TargetResource
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
                         $($localizedData.FileSystemFormatMismatch -f `
-                            $AccessPath,$fileSystem,$FSFormat)
+                                $AccessPath, $fileSystem, $FSFormat)
                     ) -join '' )
             } # if
         } # if
@@ -439,7 +476,7 @@ function Set-TargetResource
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
                         $($localizedData.ChangingVolumeLabelMessage `
-                            -f $AccessPath,$FSLabel)
+                                -f $AccessPath, $FSLabel)
                     ) -join '' )
 
                 $volume | Set-Volume -NewFileSystemLabel $FSLabel
@@ -507,7 +544,7 @@ function Test-TargetResource
         $DiskId,
 
         [Parameter()]
-        [ValidateSet('Number','UniqueId','Guid')]
+        [ValidateSet('Number', 'UniqueId', 'Guid')]
         [System.String]
         $DiskIdType = 'Number',
 
@@ -524,14 +561,14 @@ function Test-TargetResource
         $AllocationUnitSize,
 
         [Parameter()]
-        [ValidateSet('NTFS','ReFS')]
+        [ValidateSet('NTFS', 'ReFS')]
         [System.String]
         $FSFormat = 'NTFS'
     )
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($localizedData.TestingDiskMessage -f $DiskIdType,$DiskId,$AccessPath)
+            $($localizedData.TestingDiskMessage -f $DiskIdType, $DiskId, $AccessPath)
         ) -join '' )
 
     # Validate the AccessPath parameter adding a trailing slash
@@ -539,7 +576,7 @@ function Test-TargetResource
 
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
-            $($localizedData.CheckDiskInitializedMessage -f $DiskIdType,$DiskId)
+            $($localizedData.CheckDiskInitializedMessage -f $DiskIdType, $DiskId)
         ) -join '' )
 
     # Get the Disk using the identifiers supplied
@@ -551,7 +588,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotFoundMessage -f $DiskIdType,$DiskId)
+                $($localizedData.DiskNotFoundMessage -f $DiskIdType, $DiskId)
             ) -join '' )
         return $false
     } # if
@@ -560,7 +597,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotOnlineMessage -f $DiskIdType,$DiskId)
+                $($localizedData.DiskNotOnlineMessage -f $DiskIdType, $DiskId)
             ) -join '' )
         return $false
     } # if
@@ -569,7 +606,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskReadOnlyMessage -f $DiskIdType,$DiskId)
+                $($localizedData.DiskReadOnlyMessage -f $DiskIdType, $DiskId)
             ) -join '' )
         return $false
     } # if
@@ -578,7 +615,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($localizedData.DiskNotGPTMessage -f $DiskIdType,$DiskId,$Disk.PartitionStyle)
+                $($localizedData.DiskNotGPTMessage -f $DiskIdType, $DiskId, $Disk.PartitionStyle)
             ) -join '' )
         return $false
     } # if
@@ -588,7 +625,7 @@ function Test-TargetResource
 
     # Check if the disk has an existing partition assigned to the access path
     $assignedPartition = $partition |
-            Where-Object -Property AccessPaths -Contains -Value $AccessPath
+        Where-Object -Property AccessPaths -Contains -Value $AccessPath
 
     if (-not $assignedPartition)
     {
@@ -608,17 +645,17 @@ function Test-TargetResource
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($localizedData.SizeMismatchMessage -f `
-                        $AccessPath,$assignedPartition.Size,$Size)
+                            $AccessPath, $assignedPartition.Size, $Size)
                 ) -join '' )
         } # if
     } # if
 
     # Prepare the AccessPath used in the CIM query (replaces '\' with '\\')
-    $queryAccessPath = $AccessPath -replace '\\','\\'
+    $queryAccessPath = $AccessPath -replace '\\', '\\'
 
     $blockSize = (Get-CimInstance `
-        -Query "SELECT BlockSize from Win32_Volume WHERE Name = '$queryAccessPath'" `
-        -ErrorAction SilentlyContinue).BlockSize
+            -Query "SELECT BlockSize from Win32_Volume WHERE Name = '$queryAccessPath'" `
+            -ErrorAction SilentlyContinue).BlockSize
 
     if ($blockSize -gt 0 -and $AllocationUnitSize -ne 0)
     {
@@ -628,7 +665,7 @@ function Test-TargetResource
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($localizedData.AllocationUnitSizeMismatchMessage -f `
-                        $AccessPath,$($blockSize.BlockSize/1KB),$($AllocationUnitSize/1KB))
+                            $AccessPath, $($blockSize.BlockSize / 1KB), $($AllocationUnitSize / 1KB))
                 ) -join '' )
         } # if
     } # if
@@ -646,7 +683,7 @@ function Test-TargetResource
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($localizedData.FileSystemFormatMismatch -f `
-                        $AccessPath,$fileSystem,$FSFormat)
+                            $AccessPath, $fileSystem, $FSFormat)
                 ) -join '' )
         } # if
     } # if
@@ -661,7 +698,7 @@ function Test-TargetResource
             Write-Verbose -Message ( @(
                     "$($MyInvocation.MyCommand): "
                     $($localizedData.DriveLabelMismatch -f `
-                        $AccessPAth,$label,$FSLabel)
+                            $AccessPAth, $label, $FSLabel)
                 ) -join '' )
             return $false
         } # if

--- a/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/en-us/MSFT_xDiskAccessPath.strings.psd1
+++ b/Modules/xStorage/DSCResources/MSFT_xDiskAccessPath/en-us/MSFT_xDiskAccessPath.strings.psd1
@@ -26,6 +26,9 @@
     DriveLabelMismatch = Volume assigned to access path '{0}' label '{1}' does not match expected label '{2}'.
     PartitionAlreadyAssignedMessage = Partition '{1}' is already assigned to access path '{0}'.
     MatchingPartitionNotFoundMessage = Disk with {0} '{1}' already contains paritions, but none match required size.
+    MatchingPartitionNoSizeMessage = Disk with {0} '{1}' already contains partitions, but size parameter is not specified.
+    SearchForVolumeMessage = Searching for {3} volume not assigned to path on partition '{2}' disk with {0} '{1}'.
+    VolumeFoundMessage = Found {3} volume not assigned to path on partition '{2}' disk with {0} '{1}'.
     MatchingPartitionFoundMessage = Disk with {0} '{1}' already contains paritions, and partition '{2}' matches required size.
     AccessPathNotFoundOnPartitionMessage = Disk with {0} '{1}' does not contain a partition assigned to access path '{2}'.
 

--- a/Modules/xStorage/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/Modules/xStorage/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -153,7 +153,40 @@ function Get-DiskByIdentifier
     return $disk
 } # end function Get-DiskByIdentifier
 
+<#
+    .SYNOPSIS
+    Tests if any of the access paths from a partition are assigned
+    to a local path.
+
+    .PARAMETER AccessPath
+    Specifies the access paths that are assigned to the partition.
+#>
+function Test-AccessPathAssignedToLocal
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String[]]
+        $AccessPath
+    )
+
+    $accessPathAssigned = $false
+    foreach ($path in $AccessPath)
+    {
+        if ($path -match '[a-zA-Z]:\\')
+        {
+            $accessPathAssigned = $true
+            break
+        }
+    }
+
+    return $accessPathAssigned
+} # end function Test-AccessPathLocal
+
 Export-ModuleMember -Function `
     Assert-DriveLetterValid, `
     Assert-AccessPathValid, `
-    Get-DiskByIdentifier
+    Get-DiskByIdentifier,
+    Test-AccessPathAssignedToLocal

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -65,8 +65,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -104,8 +110,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -188,8 +200,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -229,8 +247,14 @@ try
                         & "$($script:DSCResourceName)_ConfigDestructive" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -269,8 +293,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -348,8 +378,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -387,8 +423,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -463,8 +505,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -507,8 +555,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 

--- a/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDisk.Integration.Tests.ps1
@@ -45,82 +45,83 @@ try
                 $driveLetterB = [char](([int][char]$lastDrive) + 2)
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterA
-                                DiskId      = $disk.Number
-                                DiskIdType  = 'Number'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterA
+                                    DiskId      = $disk.Number
+                                    DiskIdType  = 'Number'
+                                    FSLabel     = $FSLabelA
+                                    Size        = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Number
-                $current.DriveLetter      | Should -Be $driveLetterA
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterB
-                                DiskId      = $disk.Number
-                                DiskIdType  = 'Number'
-                                FSLabel     = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Number
-                $current.DriveLetter      | Should -Be $driveLetterB
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.DriveLetter      | Should -Be $driveLetterA
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+            }
+
+            Context "Create second volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterB
+                                    DiskId      = $disk.Number
+                                    DiskIdType  = 'Number'
+                                    FSLabel     = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.DriveLetter      | Should -Be $driveLetterB
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 935198720
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
@@ -134,11 +135,11 @@ try
             #>
             $drives = Get-PSDrive
 
-            It "should have attached drive $driveLetterA" {
+            It "Should have attached drive $driveLetterA" {
                 $drives | Where-Object -Property Name -eq $driveLetterA | Should -Not -BeNullOrEmpty
             }
 
-            It "should have attached drive $driveLetterB" {
+            It "Should have attached drive $driveLetterB" {
                 $drives | Where-Object -Property Name -eq $driveLetterB | Should -Not -BeNullOrEmpty
             }
 
@@ -167,125 +168,125 @@ try
                 $driveLetterB = [char](([int][char]$lastDrive) + 2)
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterA
-                                DiskId      = $disk.UniqueId
-                                DiskIdType  = 'UniqueId'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Unique Id $($disk.UniqueId)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterA
+                                    DiskId      = $disk.UniqueId
+                                    DiskIdType  = 'UniqueId'
+                                    FSLabel     = $FSLabelA
+                                    Size        = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.DriveLetter      | Should -Be $driveLetterA
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            #region DEFAULT TESTS Resize/Reformat
-            It 'should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName      = 'localhost'
-                                DriveLetter   = $driveLetterA
-                                DiskId        = $disk.UniqueId
-                                DiskIdType    = 'UniqueId'
-                                FSLabel       = $FSLabelA
-                                Size          = 900MB
-                                FSFormat      = 'ReFS'
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_ConfigDestructive" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigDestructive"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.DriveLetter      | Should -Be $driveLetterA
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 900MB
-                $current.FSFormat         | Should -Be 'ReFS'
-            }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterB
-                                DiskId      = $disk.UniqueId
-                                DiskIdType  = 'UniqueId'
-                                FSLabel     = $FSLabelB
-                            }
-                        )
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                     }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.DriveLetter      | Should -Be $driveLetterA
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.DriveLetter      | Should -Be $driveLetterB
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 96337920
+            }
+
+            Context "Resize first volume on Disk Unique Id $($disk.UniqueId)" {
+                It 'should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterA
+                                    DiskId      = $disk.UniqueId
+                                    DiskIdType  = 'UniqueId'
+                                    FSLabel     = $FSLabelA
+                                    Size        = 900MB
+                                    FSFormat    = 'ReFS'
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_ConfigDestructive" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_ConfigDestructive"
+                    }
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.DriveLetter      | Should -Be $driveLetterA
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 900MB
+                    $current.FSFormat         | Should -Be 'ReFS'
+                }
+            }
+
+            Context "Create second volume on Disk Unique Id $($disk.UniqueId)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterB
+                                    DiskId      = $disk.UniqueId
+                                    DiskIdType  = 'UniqueId'
+                                    FSLabel     = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.DriveLetter      | Should -Be $driveLetterB
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 96337920
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
@@ -327,83 +328,83 @@ try
                 $driveLetterB = [char](([int][char]$lastDrive) + 2)
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterA
-                                DiskId      = $disk.Guid
-                                DiskIdType  = 'Guid'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Guid $($disk.Guid)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterA
+                                    DiskId      = $disk.Guid
+                                    DiskIdType  = 'Guid'
+                                    FSLabel     = $FSLabelA
+                                    Size        = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.DriveLetter      | Should -Be $driveLetterA
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterB
-                                DiskId      = $disk.Guid
-                                DiskIdType  = 'Guid'
-                                FSLabel     = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.DriveLetter      | Should -Be $driveLetterB
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Guid
+                    $current.DriveLetter      | Should -Be $driveLetterA
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+            }
+
+            Context "Create first volume on Disk Guid $($disk.Guid)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName    = 'localhost'
+                                    DriveLetter = $driveLetterB
+                                    DiskId      = $disk.Guid
+                                    DiskIdType  = 'Guid'
+                                    FSLabel     = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Guid
+                    $current.DriveLetter      | Should -Be $driveLetterB
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 935198720
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
@@ -425,123 +426,6 @@ try
             }
         }
         #endregion
-
-        #region Integration Tests for Disk Guid
-        Context 'Partition and format newly provisioned disk using Guid with two volumes and assign Drive Letters' {
-            BeforeAll {
-                # Create a VHD and attach it to the computer
-                $VHDPath = Join-Path -Path $TestDrive `
-                    -ChildPath 'TestDisk.vhd'
-                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Initialize
-                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
-                $diskImage = Get-DiskImage -ImagePath $VHDPath
-                $disk = Get-Disk -Number $diskImage.Number
-                $FSLabelA = 'TestDiskA'
-                $FSLabelB = 'TestDiskB'
-
-                # Get a spare drive letter
-                $lastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
-                $driveLetterA = [char](([int][char]$lastDrive) + 1)
-                $driveLetterB = [char](([int][char]$lastDrive) + 2)
-            }
-
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterA
-                                DiskId      = $disk.Guid
-                                DiskIdType  = 'Guid'
-                                FSLabel     = $FSLabelA
-                                Size        = 100MB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
-                }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.DriveLetter      | Should -Be $driveLetterA
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
-
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName    = 'localhost'
-                                DriveLetter = $driveLetterB
-                                DiskId      = $disk.Guid
-                                DiskIdType  = 'Guid'
-                                FSLabel     = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-            #endregion
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
-                }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.DriveLetter      | Should -Be $driveLetterB
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
-            }
-
-            # A system partition will have been added to the disk as well as the 2 test partitions
-            It 'Should have 3 partitions on disk' {
-                ($disk | Get-Partition).Count | Should -Be 3
-            }
-
-            It "should have attached drive $driveLetterA" {
-                Get-PSDrive -Name $driveLetterA -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
-            }
-
-            It "should have attached drive $driveLetterB" {
-                Get-PSDrive -Name $driveLetterB -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
-            }
-
-            AfterAll {
-                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
-                $null = Remove-Item -Path $VHDPath -Force
-            }
-        }
     }
     #endregion
 }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -53,45 +53,45 @@ try
                 } # if
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.Number
-                                DiskIdType = 'Number'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Number
+                                    DiskIdType = 'Number'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Number
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+            }
             # Create a file on the new disk to ensure it still exists after reattach
             $testFilePath = Join-Path -Path $accessPathA -ChildPath 'IntTestFile.txt'
             Set-Content `
@@ -105,91 +105,92 @@ try
                 -PartitionNumber 2 `
                 -AccessPath $accessPathA
 
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.Number
-                                DiskIdType = 'Number'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Remount first volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Number
+                                    DiskIdType = 'Number'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Number
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            It 'Should contain the test file' {
-                Test-Path -Path $testFilePath        | Should -Be $true
-                Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
-            }
-
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathB
-                                DiskId     = $disk.Number
-                                DiskIdType = 'Number'
-                                FSLabel    = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Number
-                $current.AccessPath       | Should -Be "$($accessPathB)\"
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+
+                It 'Should contain the test file' {
+                    Test-Path -Path $testFilePath        | Should -Be $true
+                    Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
+                }
+
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathB
+                                    DiskId     = $disk.Number
+                                    DiskIdType = 'Number'
+                                    FSLabel    = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.AccessPath       | Should -Be "$($accessPathB)\"
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 935198720
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
             It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should -Be 3
             }
-            #endregion
 
             AfterAll {
                 # Clean up
@@ -236,43 +237,44 @@ try
                 } # if
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.UniqueId
-                                DiskIdType = 'UniqueId'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Unique Id $($disk.UniqueId)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.UniqueId
+                                    DiskIdType = 'UniqueId'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
             }
 
             # Create a file on the new disk to ensure it still exists after reattach
@@ -288,91 +290,92 @@ try
                 -PartitionNumber 2 `
                 -AccessPath $accessPathA
 
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.UniqueId
-                                DiskIdType = 'UniqueId'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Remount first volume on Disk Unique Id $($disk.UniqueId)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.UniqueId
+                                    DiskIdType = 'UniqueId'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            It 'Should contain the test file' {
-                Test-Path -Path $testFilePath        | Should -Be $true
-                Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
-            }
-
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathB
-                                DiskId     = $disk.UniqueId
-                                DiskIdType = 'UniqueId'
-                                FSLabel    = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.UniqueId
-                $current.AccessPath       | Should -Be "$($accessPathB)\"
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+
+                It 'Should contain the test file' {
+                    Test-Path -Path $testFilePath        | Should -Be $true
+                    Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
+                }
+
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathB
+                                    DiskId     = $disk.UniqueId
+                                    DiskIdType = 'UniqueId'
+                                    FSLabel    = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.UniqueId
+                    $current.AccessPath       | Should -Be "$($accessPathB)\"
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 935198720
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
             It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should -Be 3
             }
-            #endregion
 
             AfterAll {
                 # Clean up
@@ -419,43 +422,44 @@ try
                 } # if
             }
 
-            #region DEFAULT TESTS
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.Guid
-                                DiskIdType = 'Guid'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Create first volume on Disk Guid $($disk.Guid)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Guid
+                                    DiskIdType = 'Guid'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Guid
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
             }
 
             # Create a file on the new disk to ensure it still exists after reattach
@@ -471,91 +475,92 @@ try
                 -PartitionNumber 2 `
                 -AccessPath $accessPathA
 
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathA
-                                DiskId     = $disk.Guid
-                                DiskIdType = 'Guid'
-                                FSLabel    = $FSLabelA
-                                Size       = 100MB
-                            }
-                        )
-                    }
+            Context "Remount first volume on Disk Guid $($disk.Guid)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Guid
+                                    DiskIdType = 'Guid'
+                                    FSLabel    = $FSLabelA
+                                    Size       = 100MB
+                                }
+                            )
+                        }
 
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.AccessPath       | Should -Be "$($accessPathA)\"
-                $current.FSLabel          | Should -Be $FSLabelA
-                $current.Size             | Should -Be 100MB
-            }
 
-            It 'Should contain the test file' {
-                Test-Path -Path $testFilePath        | Should -Be $true
-                Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
-            }
-
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    # This is to pass to the Config
-                    $configData = @{
-                        AllNodes = @(
-                            @{
-                                NodeName   = 'localhost'
-                                AccessPath = $accessPathB
-                                DiskId     = $disk.Guid
-                                DiskIdType = 'Guid'
-                                FSLabel    = $FSLabelB
-                            }
-                        )
-                    }
-
-                    & "$($script:DSCResourceName)_Config" `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $configData
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration | Where-Object {
-                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
-                $current.DiskId           | Should -Be $disk.Guid
-                $current.AccessPath       | Should -Be "$($accessPathB)\"
-                $current.FSLabel          | Should -Be $FSLabelB
-                $current.Size             | Should -Be 935198720
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Guid
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                    $current.Size             | Should -Be 100MB
+                }
+
+                It 'Should contain the test file' {
+                    Test-Path -Path $testFilePath        | Should -Be $true
+                    Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
+                }
+
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathB
+                                    DiskId     = $disk.Guid
+                                    DiskIdType = 'Guid'
+                                    FSLabel    = $FSLabelB
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+                        Start-DscConfiguration -Path $TestDrive `
+                            -ComputerName localhost -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Guid
+                    $current.AccessPath       | Should -Be "$($accessPathB)\"
+                    $current.FSLabel          | Should -Be $FSLabelB
+                    $current.Size             | Should -Be 935198720
+                }
             }
 
             # A system partition will have been added to the disk as well as the 2 test partitions
             It 'Should have 3 partitions on disk' {
                 ($disk | Get-Partition).Count | Should -Be 3
             }
-            #endregion
 
             AfterAll {
                 # Clean up
@@ -575,7 +580,6 @@ try
         }
         #endregion
     }
-    #endregion
 }
 finally
 {

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -73,8 +73,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -103,7 +109,8 @@ try
             Remove-PartitionAccessPath `
                 -DiskNumber $disk.Number `
                 -PartitionNumber 2 `
-                -AccessPath $accessPathA
+                -AccessPath $accessPathA `
+                -ErrorAction SilentlyContinue
 
             Context "Remount first volume on Disk Number $($disk.Number)" {
                 It 'Should compile and apply the MOF without throwing' {
@@ -125,8 +132,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -167,8 +180,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -197,11 +216,13 @@ try
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 2 `
-                    -AccessPath $accessPathA
+                    -AccessPath $accessPathA `
+                    -ErrorAction SilentlyContinue
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 3 `
-                    -AccessPath $accessPathB
+                    -AccessPath $accessPathB `
+                    -ErrorAction SilentlyContinue
                 $null = Remove-Item -Path $accessPathA -Force
                 $null = Remove-Item -Path $accessPathB -Force
                 $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
@@ -257,8 +278,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -310,8 +337,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -352,8 +385,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -382,11 +421,13 @@ try
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 2 `
-                    -AccessPath $accessPathA
+                    -AccessPath $accessPathA `
+                    -ErrorAction SilentlyContinue
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 3 `
-                    -AccessPath $accessPathB
+                    -AccessPath $accessPathB `
+                    -ErrorAction SilentlyContinue
                 $null = Remove-Item -Path $accessPathA -Force
                 $null = Remove-Item -Path $accessPathB -Force
                 $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
@@ -442,8 +483,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -473,7 +520,8 @@ try
             Remove-PartitionAccessPath `
                 -DiskNumber $disk.Number `
                 -PartitionNumber 2 `
-                -AccessPath $accessPathA
+                -AccessPath $accessPathA `
+                -ErrorAction SilentlyContinue
 
             Context "Remount first volume on Disk Guid $($disk.Guid)" {
                 It 'Should compile and apply the MOF without throwing' {
@@ -495,8 +543,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -537,8 +591,14 @@ try
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
-                        Start-DscConfiguration -Path $TestDrive `
-                            -ComputerName localhost -Wait -Verbose -Force
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
                     } | Should -Not -Throw
                 }
 
@@ -567,13 +627,159 @@ try
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 2 `
-                    -AccessPath $accessPathA
+                    -AccessPath $accessPathA `
+                    -ErrorAction SilentlyContinue
                 Remove-PartitionAccessPath `
                     -DiskNumber $disk.Number `
                     -PartitionNumber 3 `
-                    -AccessPath $accessPathB
+                    -AccessPath $accessPathB `
+                    -ErrorAction SilentlyContinue
                 $null = Remove-Item -Path $accessPathA -Force
                 $null = Remove-Item -Path $accessPathB -Force
+                $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
+                $null = Remove-Item -Path $VHDPath -Force
+            }
+        }
+        #endregion
+
+        #region Integration Tests for DiskNumber to test if a single disk with a volume using the whole disk can be remounted
+        Context 'Partition a disk using Disk Number with a single volume using the whole disk, dismount the volume then reprovision it' {
+            BeforeAll {
+                # Create a VHD and attach it to the computer
+                $VHDPath = Join-Path -Path $TestDrive `
+                    -ChildPath 'TestDisk.vhd'
+                $null = New-VDisk -Path $VHDPath -SizeInMB 1024 -Verbose
+                $null = Mount-DiskImage -ImagePath $VHDPath -StorageType VHD -NoDriveLetter
+                $diskImage = Get-DiskImage -ImagePath $VHDPath
+                $disk = Get-Disk -Number $diskImage.Number
+                $FSLabelA = 'TestDiskA'
+
+                # Get a mount point path
+                $accessPathA = Join-Path -Path $ENV:Temp -ChildPath 'xDiskAccessPath_MountA'
+                if (-not (Test-Path -Path $accessPathA))
+                {
+                    $null = New-Item -Path $accessPathA -ItemType Directory
+                } # if
+            }
+
+            Context "Create first volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Number
+                                    DiskIdType = 'Number'
+                                    FSLabel    = $FSLabelA
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                }
+            }
+            # Create a file on the new disk to ensure it still exists after reattach
+            $testFilePath = Join-Path -Path $accessPathA -ChildPath 'IntTestFile.txt'
+            Set-Content `
+                -Path $testFilePath `
+                -Value 'Test' `
+                -NoNewline
+
+            # This test will ensure the disk can be remounted if the access path is removed.
+            Remove-PartitionAccessPath `
+                -DiskNumber $disk.Number `
+                -PartitionNumber 2 `
+                -AccessPath $accessPathA
+
+            Context "Remount first volume on Disk Number $($disk.Number)" {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName   = 'localhost'
+                                    AccessPath = $accessPathA
+                                    DiskId     = $disk.Number
+                                    DiskIdType = 'Number'
+                                    FSLabel    = $FSLabelA
+                                }
+                            )
+                        }
+
+                        & "$($script:DSCResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
+                    } | Should -Not -Throw
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object {
+                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                    }
+                    $current.DiskId           | Should -Be $disk.Number
+                    $current.AccessPath       | Should -Be "$($accessPathA)\"
+                    $current.FSLabel          | Should -Be $FSLabelA
+                }
+
+                It 'Should contain the test file' {
+                    Test-Path -Path $testFilePath        | Should -Be $true
+                    Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
+                }
+            }
+
+            # A system partition will have been added to the disk as well as the 2 test partitions
+            It 'Should have 2 partitions on disk' {
+                ($disk | Get-Partition).Count | Should -Be 2
+            }
+
+            AfterAll {
+                # Clean up
+                Remove-PartitionAccessPath `
+                    -DiskNumber $disk.Number `
+                    -PartitionNumber 2 `
+                    -AccessPath $accessPathA `
+                    -ErrorAction SilentlyContinue
+                $null = Remove-Item -Path $accessPathA -Force
                 $null = Dismount-DiskImage -ImagePath $VHDPath -StorageType VHD
                 $null = Remove-Item -Path $VHDPath -Force
             }

--- a/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDiskAccessPath.Integration.Tests.ps1
@@ -162,47 +162,49 @@ try
                     Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
-                    {
-                        # This is to pass to the Config
-                        $configData = @{
-                            AllNodes = @(
-                                @{
-                                    NodeName   = 'localhost'
-                                    AccessPath = $accessPathB
-                                    DiskId     = $disk.Number
-                                    DiskIdType = 'Number'
-                                    FSLabel    = $FSLabelB
-                                }
-                            )
-                        }
+                Context "Create second volume on Disk Number $($disk.Number)" {
+                    It 'Should compile and apply the MOF without throwing' {
+                        {
+                            # This is to pass to the Config
+                            $configData = @{
+                                AllNodes = @(
+                                    @{
+                                        NodeName   = 'localhost'
+                                        AccessPath = $accessPathB
+                                        DiskId     = $disk.Number
+                                        DiskIdType = 'Number'
+                                        FSLabel    = $FSLabelB
+                                    }
+                                )
+                            }
 
-                        & "$($script:DSCResourceName)_Config" `
-                            -OutputPath $TestDrive `
-                            -ConfigurationData $configData
+                            & "$($script:DSCResourceName)_Config" `
+                                -OutputPath $TestDrive `
+                                -ConfigurationData $configData
 
-                        Start-DscConfiguration `
-                            -Path $TestDrive `
-                            -ComputerName localhost `
-                            -Wait `
-                            -Verbose `
-                            -Force `
-                            -ErrorAction Stop
-                    } | Should -Not -Throw
-                }
-
-                It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-                }
-
-                It 'Should have set the resource and all the parameters should match' {
-                    $current = Get-DscConfiguration | Where-Object {
-                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                            Start-DscConfiguration `
+                                -Path $TestDrive `
+                                -ComputerName localhost `
+                                -Wait `
+                                -Verbose `
+                                -Force `
+                                -ErrorAction Stop
+                        } | Should -Not -Throw
                     }
-                    $current.DiskId           | Should -Be $disk.Number
-                    $current.AccessPath       | Should -Be "$($accessPathB)\"
-                    $current.FSLabel          | Should -Be $FSLabelB
-                    $current.Size             | Should -Be 935198720
+
+                    It 'Should be able to call Get-DscConfiguration without throwing' {
+                        { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    }
+
+                    It 'Should have set the resource and all the parameters should match' {
+                        $current = Get-DscConfiguration | Where-Object {
+                            $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        }
+                        $current.DiskId           | Should -Be $disk.Number
+                        $current.AccessPath       | Should -Be "$($accessPathB)\"
+                        $current.FSLabel          | Should -Be $FSLabelB
+                        $current.Size             | Should -Be 935198720
+                    }
                 }
             }
 
@@ -367,47 +369,49 @@ try
                     Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
-                    {
-                        # This is to pass to the Config
-                        $configData = @{
-                            AllNodes = @(
-                                @{
-                                    NodeName   = 'localhost'
-                                    AccessPath = $accessPathB
-                                    DiskId     = $disk.UniqueId
-                                    DiskIdType = 'UniqueId'
-                                    FSLabel    = $FSLabelB
-                                }
-                            )
-                        }
+                Context "Create second volume on Disk Unique Id $($disk.UniqueId)" {
+                    It 'Should compile and apply the MOF without throwing' {
+                        {
+                            # This is to pass to the Config
+                            $configData = @{
+                                AllNodes = @(
+                                    @{
+                                        NodeName   = 'localhost'
+                                        AccessPath = $accessPathB
+                                        DiskId     = $disk.UniqueId
+                                        DiskIdType = 'UniqueId'
+                                        FSLabel    = $FSLabelB
+                                    }
+                                )
+                            }
 
-                        & "$($script:DSCResourceName)_Config" `
-                            -OutputPath $TestDrive `
-                            -ConfigurationData $configData
+                            & "$($script:DSCResourceName)_Config" `
+                                -OutputPath $TestDrive `
+                                -ConfigurationData $configData
 
-                        Start-DscConfiguration `
-                            -Path $TestDrive `
-                            -ComputerName localhost `
-                            -Wait `
-                            -Verbose `
-                            -Force `
-                            -ErrorAction Stop
-                    } | Should -Not -Throw
-                }
-
-                It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-                }
-
-                It 'Should have set the resource and all the parameters should match' {
-                    $current = Get-DscConfiguration | Where-Object {
-                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                            Start-DscConfiguration `
+                                -Path $TestDrive `
+                                -ComputerName localhost `
+                                -Wait `
+                                -Verbose `
+                                -Force `
+                                -ErrorAction Stop
+                        } | Should -Not -Throw
                     }
-                    $current.DiskId           | Should -Be $disk.UniqueId
-                    $current.AccessPath       | Should -Be "$($accessPathB)\"
-                    $current.FSLabel          | Should -Be $FSLabelB
-                    $current.Size             | Should -Be 935198720
+
+                    It 'Should be able to call Get-DscConfiguration without throwing' {
+                        { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    }
+
+                    It 'Should have set the resource and all the parameters should match' {
+                        $current = Get-DscConfiguration | Where-Object {
+                            $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        }
+                        $current.DiskId           | Should -Be $disk.UniqueId
+                        $current.AccessPath       | Should -Be "$($accessPathB)\"
+                        $current.FSLabel          | Should -Be $FSLabelB
+                        $current.Size             | Should -Be 935198720
+                    }
                 }
             }
 
@@ -573,47 +577,49 @@ try
                     Get-Content -Path $testFilePath -Raw | Should -Be 'Test'
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
-                    {
-                        # This is to pass to the Config
-                        $configData = @{
-                            AllNodes = @(
-                                @{
-                                    NodeName   = 'localhost'
-                                    AccessPath = $accessPathB
-                                    DiskId     = $disk.Guid
-                                    DiskIdType = 'Guid'
-                                    FSLabel    = $FSLabelB
-                                }
-                            )
-                        }
+                Context "Create second volume on Disk Guid $($disk.Guid)" {
+                    It 'Should compile and apply the MOF without throwing' {
+                        {
+                            # This is to pass to the Config
+                            $configData = @{
+                                AllNodes = @(
+                                    @{
+                                        NodeName   = 'localhost'
+                                        AccessPath = $accessPathB
+                                        DiskId     = $disk.Guid
+                                        DiskIdType = 'Guid'
+                                        FSLabel    = $FSLabelB
+                                    }
+                                )
+                            }
 
-                        & "$($script:DSCResourceName)_Config" `
-                            -OutputPath $TestDrive `
-                            -ConfigurationData $configData
+                            & "$($script:DSCResourceName)_Config" `
+                                -OutputPath $TestDrive `
+                                -ConfigurationData $configData
 
-                        Start-DscConfiguration `
-                            -Path $TestDrive `
-                            -ComputerName localhost `
-                            -Wait `
-                            -Verbose `
-                            -Force `
-                            -ErrorAction Stop
-                    } | Should -Not -Throw
-                }
-
-                It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-                }
-
-                It 'Should have set the resource and all the parameters should match' {
-                    $current = Get-DscConfiguration | Where-Object {
-                        $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                            Start-DscConfiguration `
+                                -Path $TestDrive `
+                                -ComputerName localhost `
+                                -Wait `
+                                -Verbose `
+                                -Force `
+                                -ErrorAction Stop
+                        } | Should -Not -Throw
                     }
-                    $current.DiskId           | Should -Be $disk.Guid
-                    $current.AccessPath       | Should -Be "$($accessPathB)\"
-                    $current.FSLabel          | Should -Be $FSLabelB
-                    $current.Size             | Should -Be 935198720
+
+                    It 'Should be able to call Get-DscConfiguration without throwing' {
+                        { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    }
+
+                    It 'Should have set the resource and all the parameters should match' {
+                        $current = Get-DscConfiguration | Where-Object {
+                            $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                        }
+                        $current.DiskId           | Should -Be $disk.Guid
+                        $current.AccessPath       | Should -Be "$($accessPathB)\"
+                        $current.FSLabel          | Should -Be $FSLabelB
+                        $current.Size             | Should -Be 935198720
+                    }
                 }
             }
 

--- a/Tests/Unit/MSFT_xDisk.Tests.ps1
+++ b/Tests/Unit/MSFT_xDisk.Tests.ps1
@@ -117,6 +117,7 @@ try
         $script:mockedVolume = [pscustomobject] @{
             FileSystemLabel = 'myLabel'
             FileSystem      = 'NTFS'
+            DriveLetter     = $script:testDriveLetter
         }
 
         $script:mockedVolumeUnformatted = [pscustomobject] @{
@@ -127,11 +128,13 @@ try
         $script:mockedVolumeNoDriveLetter = [pscustomobject] @{
             FileSystemLabel = 'myLabel'
             FileSystem      = 'NTFS'
+            DriveLetter     = ''
         }
 
         $script:mockedVolumeReFS = [pscustomobject] @{
             FileSystemLabel = 'myLabel'
             FileSystem      = 'ReFS'
+            DriveLetter     = $script:testDriveLetter
         }
         #endregion
 
@@ -1129,7 +1132,7 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 31
-                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
                     Assert-MockCalled -CommandName New-Partition -Exactly -Times 1 `
                         -ParameterFilter {
                         $DriveLetter -eq $script:testDriveLetter
@@ -1422,7 +1425,7 @@ try
                     Assert-MockCalled -CommandName Set-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Initialize-Disk -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-Partition -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Volume -Exactly -Times 2
                     Assert-MockCalled -CommandName New-Partition -Exactly -Times 1
                     Assert-MockCalled -CommandName Format-Volume -Exactly -Times 0
                     Assert-MockCalled -CommandName Set-Partition -Exactly -Times 1
@@ -1634,7 +1637,7 @@ try
                 Mock -CommandName Format-Volume
                 Mock -CommandName Set-Partition
                 Mock -CommandName Resize-Partition
-                 Mock  -CommandName Get-PartitionSupportedSize
+                Mock  -CommandName Get-PartitionSupportedSize
 
                 It 'Should not throw an exception' {
                     {

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -330,7 +330,6 @@ try
                         -AccessPath @('\\?\Volume{905551f3-33a5-421d-ac24-c993fbfb3184}\','\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false
                 }
             }
-
         }
         #endregion
     }

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -317,14 +317,14 @@ try
                 }
             }
 
-            Context 'Contains mulitple access paths where one is local' {
+            Context 'Contains multiple access paths where one is local' {
                 It 'Should return $true' {
                     Test-AccessPathAssignedToLocal `
                         -AccessPath @('c:\MountPoint\', '\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $true
                 }
             }
 
-            Context 'Contains mulitple access paths where none are local' {
+            Context 'Contains multiple access paths where none are local' {
                 It 'Should return $false' {
                     Test-AccessPathAssignedToLocal `
                         -AccessPath @('\\?\Volume{905551f3-33a5-421d-ac24-c993fbfb3184}\','\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false

--- a/Tests/Unit/StorageDsc.Common.Tests.ps1
+++ b/Tests/Unit/StorageDsc.Common.Tests.ps1
@@ -301,6 +301,38 @@ try
             }
         }
         #endregion Function Get-DiskByIdentifier
+
+        Describe "StorageDsc.Common\Test-AccessPathAssignedToLocal" {
+            Context 'Contains a single access path that is local' {
+                It 'Should return $true' {
+                    Test-AccessPathAssignedToLocal `
+                        -AccessPath @('c:\MountPoint\') | Should -Be $true
+                }
+            }
+
+            Context 'Contains a single access path that is not local' {
+                It 'Should return $false' {
+                    Test-AccessPathAssignedToLocal `
+                        -AccessPath @('\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false
+                }
+            }
+
+            Context 'Contains mulitple access paths where one is local' {
+                It 'Should return $true' {
+                    Test-AccessPathAssignedToLocal `
+                        -AccessPath @('c:\MountPoint\', '\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $true
+                }
+            }
+
+            Context 'Contains mulitple access paths where none are local' {
+                It 'Should return $false' {
+                    Test-AccessPathAssignedToLocal `
+                        -AccessPath @('\\?\Volume{905551f3-33a5-421d-ac24-c993fbfb3184}\','\\?\Volume{99cf0194-ac45-4a23-b36e-3e458158a63e}\') | Should -Be $false
+                }
+            }
+
+        }
+        #endregion
     }
     #endregion Pester Tests
 }


### PR DESCRIPTION
**Pull Request (PR) description**
This PR fixes the issue in xDisk and xDiskAccessPath that occurs when the Size parameter is not specified, but the partition on the disk already exists but is not assigned to a Drive Letter or an Access Path.

This also improves the integration test layout by adding contexts to group the tests.

**This Pull Request (PR) fixes the following issues:**
- Fixes #103 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - another one for you sir if you get time -no rush! :grin: I applied autoformatting to the files as well, which did correct some of the lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/130)
<!-- Reviewable:end -->
