### PR TITLE
Moved entry for new xOpticalDiskDriveLetter resource into Unreleased section - Fixes #135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- xOpticalDiskDriveLetter:
+  - Added new resource.
+  - Added support for setting the drive letter of optical drives (CD/DVD drives).
+
 ## 3.4.0.0
 
 - xDisk:
@@ -14,9 +18,6 @@
   - Fix bug when size not specified and disk partitioned and
     formatted but not assigned to path - See [Issue 103](https://github.com/PowerShell/xStorage/issues/103).
 - Updated tests to meet Pester V4 guidelines - fixes [Issue #120](https://github.com/PowerShell/xStorage/issues/120).
-- xOpticalDiskDriveLetter:
-  - Added new resource.
-  - Added support for setting the drive letter of optical drives (CD/DVD drives).
 
 ## 3.3.0.0
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR is to correct the CHANGELOG.MD entry for a previous PR #133.

The entry got put into the released (3.4.0.0) section instead of the UNRELEASED section.

**This Pull Request (PR) fixes the following issues:**
- #135

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - would you mind reviewing this? It is just a minor correction to a previous PR I merged (it was looked to be easier to fix in a separate PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/136)
<!-- Reviewable:end -->
