### PR TITLE
Refactored xOpticalDiskDriveLetter to be IsSingleInstance - Fixes #138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - xOpticalDiskDriveLetter:
   - Added new resource.
   - Added support for setting the drive letter of optical drives (CD/DVD drives).
+  - Converted to be single instance pattern.
+  - Removed ShouldProcess from `Set-TargetResource`.
+  - Optimized `Test-TargetResource` to reduce code duplication.
 
 ## 3.4.0.0
 

--- a/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.psm1
@@ -237,7 +237,7 @@ function Test-TargetResource
     # Allow use of drive letter without colon
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter -Colon
 
-    # Is there a optical disk?
+    # Is there an optical disk?
     $opticalDrive = Get-CimInstance -ClassName Win32_CDROMDrive -Property Id
 
     # What type of drive is attached to $driveletter
@@ -246,7 +246,7 @@ function Test-TargetResource
         -Filter "DriveLetter = '$DriveLetter'" `
         -Property DriveType
 
-    # Check there is a optical disk
+    # Check there is an optical disk
     if ($opticalDrive)
     {
         Write-Verbose -Message ( @(
@@ -273,7 +273,7 @@ function Test-TargetResource
             $result = $false
         }
 
-        # Return false if the drive letter specified is a optical disk resource & $Ensure -eq 'Absent'
+        # Return false if the drive letter specified is an optical disk resource & $Ensure -eq 'Absent'
         if ($Ensure -eq 'Absent')
         {
             $result = -not $result

--- a/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.psm1
+++ b/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.psm1
@@ -7,13 +7,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Storage Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.Common' `
-                                                     -ChildPath 'StorageDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.Common' `
+            -ChildPath 'StorageDsc.Common.psm1'))
 
 # Import the Storage Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
-                                                     -ChildPath 'StorageDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'StorageDsc.ResourceHelper' `
+            -ChildPath 'StorageDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -40,12 +40,12 @@ function Get-OpticalDiskDriveLetter
         Example DeviceID for a mounted ISO   in a Hyper-V VM - SCSI\CDROM&VEN_MSFT&PROD_VIRTUAL_DVD-ROM\2&1F4ADFFE&0&000002
     #>
     $driveLetter = (Get-CimInstance -ClassName Win32_CDROMDrive | Where-Object {
-        -not (
+            -not (
                 $_.Caption -eq 'Microsoft Virtual DVD-ROM' -and
                 ($_.DeviceID.Split('\')[-1]).Length -gt 10
             )
         }
-        ).Drive
+    ).Drive
 
     return $driveLetter
 }
@@ -54,9 +54,12 @@ function Get-OpticalDiskDriveLetter
     .SYNOPSIS
     Returns the current drive letter assigned to the optical disk.
 
-    .PARAMETER DriveLetter
-    Specifies the preferred letter to assign to the optical disk.
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
 
+    .PARAMETER DriveLetter
+    Specifies the drive letter to assign to the optical disk. Can be a
+    single letter, optionally followed by a colon.
 #>
 function Get-TargetResource
 {
@@ -64,58 +67,64 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        # specify the drive letter as a single letter, optionally include the colon
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
         [Parameter(Mandatory = $true)]
         [System.String]
         $DriveLetter
     )
 
-    # allow use of drive letter without colon
+    # Allow use of drive letter without colon
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter -Colon
 
     Write-Verbose -Message ( @(
-        "$($MyInvocation.MyCommand): "
-        $($localizedData.UsingGetCimInstanceToFetchDriveLetter)
-    ) -join '' )
+            "$($MyInvocation.MyCommand): "
+            $($localizedData.UsingGetCimInstanceToFetchDriveLetter)
+        ) -join '' )
 
     $currentDriveLetter = Get-OpticalDiskDriveLetter
 
     if (-not $currentDriveLetter)
     {
         Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.NoOpticalDiskDrive)
-        ) -join '' )
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.NoOpticalDiskDrive)
+            ) -join '' )
 
         $Ensure = 'Present'
     }
-    else 
+    else
     {
-        # check if $driveletter is the location of the optical disk
+        # Check if $driveletter is the location of the optical disk
         if ($currentDriveLetter -eq $DriveLetter)
         {
             Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.OpticalDriveSetAsRequested -f $DriveLetter)
-            ) -join '' )
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.OpticalDriveSetAsRequested -f $DriveLetter)
+                ) -join '' )
 
             $Ensure = 'Present'
         }
         else
         {
             Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.OpticalDriveNotSetAsRequested -f $currentDriveLetter,$DriveLetter)
-            ) -join '' )
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.OpticalDriveNotSetAsRequested -f $currentDriveLetter, $DriveLetter)
+                ) -join '' )
 
             $Ensure = 'Absent'
         }
     }
 
     $returnValue = @{
-                     DriveLetter = $currentDriveLetter
-                     Ensure = $Ensure
-                    }
+        IsSingleInstance = 'Yes'
+        DriveLetter      = $currentDriveLetter
+        Ensure           = $Ensure
+    }
+
     return $returnValue
 } # Get-TargetResource
 
@@ -123,8 +132,12 @@ function Get-TargetResource
     .SYNOPSIS
     Sets the drive letter of the optical disk.
 
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
     .PARAMETER DriveLetter
-    Specifies the drive letter to assign to the optical disk.
+    Specifies the drive letter to assign to the optical disk. Can be a
+    single letter, optionally followed by a colon.
 
     .PARAMETER Ensure
     Determines whether the setting should be applied or removed.
@@ -134,18 +147,22 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        # specify the drive letter as a single letter, optionally include the colon
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
         [Parameter(Mandatory = $true)]
         [System.String]
         $DriveLetter,
 
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
     )
 
-    # allow use of drive letter without colon
+    # Allow use of drive letter without colon
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter -Colon
 
     $currentDriveLetter = Get-OpticalDiskDriveLetter
@@ -155,33 +172,29 @@ function Set-TargetResource
         return
     }
 
-    # assuming a drive letter is found
+    # Assuming a drive letter is found
     if ($currentDriveLetter)
     {
         Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.AttemptingToSetDriveLetter -f $currentDriveLetter,$DriveLetter)
-        ) -join '' )
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.AttemptingToSetDriveLetter -f $currentDriveLetter, $DriveLetter)
+            ) -join '' )
 
-        if ($PSCmdlet.ShouldProcess("Setting optical disk letter to $DriveLetter"))
+        # If $Ensure -eq Absent this will remove the drive letter from the optical disk
+        if ($Ensure -eq 'Absent')
         {
-
-            # if $Ensure -eq Absent this will remove the drive letter from the optical disk
-            if ($Ensure -eq 'Absent')
-            {
-                $DriveLetter = $null
-            }
-
-            Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$currentDriveLetter'" |
-                Set-CimInstance -Property @{ DriveLetter = $DriveLetter }
+            $DriveLetter = $null
         }
+
+        Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$currentDriveLetter'" |
+            Set-CimInstance -Property @{ DriveLetter = $DriveLetter }
     }
     else
     {
         Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.NoOpticalDiskDrive)
-        ) -join '' )
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.NoOpticalDiskDrive)
+            ) -join '' )
     }
 } # Set-TargetResource
 
@@ -189,8 +202,12 @@ function Set-TargetResource
     .SYNOPSIS
     Tests the optical disk letter is set as expected
 
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
     .PARAMETER DriveLetter
-    Specifies the drive letter to test if it is assigned to the optical disk.
+    Specifies the drive letter to assign to the optical disk. Can be a
+    single letter, optionally followed by a colon.
 
     .PARAMETER Ensure
     Determines whether the setting should be applied or removed.
@@ -201,55 +218,62 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
         # specify the drive letter as a single letter, optionally include the colon
         [Parameter(Mandatory = $true)]
         [System.String]
         $DriveLetter,
 
         [Parameter()]
-        [ValidateSet('Present','Absent')]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
     )
 
-    # allow use of drive letter without colon
+    # Allow use of drive letter without colon
     $DriveLetter = Assert-DriveLetterValid -DriveLetter $DriveLetter -Colon
 
-    # is there a optical disk
+    # Is there a optical disk?
     $opticalDrive = Get-CimInstance -ClassName Win32_CDROMDrive -Property Id
 
-    # what type of drive is attached to $driveletter
-    $volumeDriveType = Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$DriveLetter'" -Property DriveType
+    # What type of drive is attached to $driveletter
+    $volumeDriveType = Get-CimInstance `
+        -ClassName Win32_Volume `
+        -Filter "DriveLetter = '$DriveLetter'" `
+        -Property DriveType
 
-    # check there is a optical disk
+    # Check there is a optical disk
     if ($opticalDrive)
     {
         Write-Verbose -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.OpticalDiskDriveFound -f $opticaDrive.id)
-        ) -join '' )
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.OpticalDiskDriveFound -f $opticaDrive.id)
+            ) -join '' )
 
         if ($volumeDriveType.DriveType -eq 5)
         {
-
             Write-Verbose -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.DriveLetterVolumeType -f $driveletter, $volumeDriveType.DriveType)
-            ) -join '' )
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DriveLetterVolumeType -f $driveletter, $volumeDriveType.DriveType)
+                ) -join '' )
+
+            $result = $true
         }
         else
         {
-
             Write-Warning -Message ( @(
-                "$($MyInvocation.MyCommand): "
-                $($localizedData.DriveLetterExistsButNotOptical -f $driveletter)
-            ) -join '' )
+                    "$($MyInvocation.MyCommand): "
+                    $($localizedData.DriveLetterExistsButNotOptical -f $driveletter)
+                ) -join '' )
+
+            $result = $false
         }
 
-        # return true if the drive letter is a optical disk resource
-        $result = [System.Boolean]($volumeDriveType.DriveType -eq 5)
-
-        # return false if the drive letter specified is a optical disk resource & $Ensure -eq 'Absent'
+        # Return false if the drive letter specified is a optical disk resource & $Ensure -eq 'Absent'
         if ($Ensure -eq 'Absent')
         {
             $result = -not $result
@@ -257,15 +281,16 @@ function Test-TargetResource
     }
     else
     {
-        # return true if there is no optical disk - can't set what isn't there!
+        # Return false if there is no optical disk - can't set what isn't there!
         Write-Warning -Message ( @(
-            "$($MyInvocation.MyCommand): "
-            $($localizedData.NoOpticalDiskDrive)
-        ) -join '' )
+                "$($MyInvocation.MyCommand): "
+                $($localizedData.NoOpticalDiskDrive)
+            ) -join '' )
 
         $result = $false
     }
-    
+
     return $result
 }
+
 Export-ModuleMember -Function *-TargetResource

--- a/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xOpticalDiskDriveLetter : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
-    [Required, Description("    Specifies the drive letter to assign to the optical disk. Can be a single letter, optionally followed by a colon.")] String DriveLetter;
+    [Required, Description("Specifies the drive letter to assign to the optical disk. Can be a single letter, optionally followed by a colon.")] String DriveLetter;
     [Write, Description("Determines whether the optical drive drive letter should be changed or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
 };
 

--- a/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.schema.mof
+++ b/Modules/xStorage/DSCResources/MSFT_xOpticalDiskDriveLetter/MSFT_xOpticalDiskDriveLetter.schema.mof
@@ -2,7 +2,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xOpticalDiskDriveLetter")]
 class MSFT_xOpticalDiskDriveLetter : OMI_BaseResource
 {
-    [Key, Description("Specifies the drive letter of the optical drive to modify.")] String DriveLetter;
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Required, Description("    Specifies the drive letter to assign to the optical disk. Can be a single letter, optionally followed by a colon.")] String DriveLetter;
     [Write, Description("Determines whether the optical drive drive letter should be changed or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
 };
 

--- a/Modules/xStorage/Examples/Resources/xOpticalDiskDriveLetter/1-xOpticalDiskDriveLetter_SetDriveLetter.ps1
+++ b/Modules/xStorage/Examples/Resources/xOpticalDiskDriveLetter/1-xOpticalDiskDriveLetter_SetDriveLetter.ps1
@@ -11,7 +11,8 @@ Configuration Example
     {
         xOpticalDiskDriveLetter MapOpticalDiskToZ
         {
-             DriveLetter = 'Z'
+            IsSingleInstance = 'Yes'
+            DriveLetter      = 'Z'
         }
     }
 }

--- a/Tests/Integration/MSFT_xOpticalDiskDriveLetter.config.ps1
+++ b/Tests/Integration/MSFT_xOpticalDiskDriveLetter.config.ps1
@@ -2,7 +2,8 @@ configuration MSFT_xOpticalDiskDriveLetter_config {
     Import-DSCResource -ModuleName xStorage
     node localhost {
         xOpticalDiskDriveLetter Integration_Test {
-            DriveLetter = $Node.DriveLetter
+            IsSingleInstance = 'Yes'
+            DriveLetter      = $Node.DriveLetter
         }
     }
 }


### PR DESCRIPTION
**Pull Request (PR) description**
This PR converts the xOpticalDiskDriveLetter resource over to use the IsSingleInstance pattern.

It also refactors some of the code and tests slightly to simplify them and to also meet HQRM and related style guidelines.

**This Pull Request (PR) fixes the following issues:**
- Fixes #138

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - would you mind reviewing? Thank you again!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xstorage/139)
<!-- Reviewable:end -->
