### PR TITLE
DISK: Add check for elevated privileges when DevDrive flag is set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.0.1] - 2024-06-11
 
+### Changed
+
+- Disk:
+  - Add check for elevated privileges when DevDrive flag is set to true -
+    Fixes [Issue #284](https://github.com/dsccommunity/StorageDsc/issues/284).
+
 ### Fixed
 
 - OpticalDiskDriveLetter:

--- a/source/DSCResources/DSC_Disk/DSC_Disk.psm1
+++ b/source/DSCResources/DSC_Disk/DSC_Disk.psm1
@@ -343,6 +343,8 @@ function Set-TargetResource
     #>
     if ($DevDrive)
     {
+        Assert-ElevatedUserWithCustomErrorMessage -CustomErrorMessage $script:localizedData.DevDriveAdminError
+
         Assert-DevDriveFeatureAvailable
         Assert-FSFormatIsReFsWhenDevDriveFlagSetToTrue -FSFormat $FSFormat
 
@@ -1222,6 +1224,7 @@ function Test-TargetResource
             $($script:localizedData.CheckingDevDriveAssertions)
         ) -join '' )
 
+        Assert-ElevatedUserWithCustomErrorMessage -CustomErrorMessage $script:localizedData.DevDriveAdminError
         Assert-DevDriveFeatureAvailable
         Assert-FSFormatIsReFsWhenDevDriveFlagSetToTrue -FSFormat $FSFormat
 

--- a/source/DSCResources/DSC_Disk/README.md
+++ b/source/DSCResources/DSC_Disk/README.md
@@ -27,16 +27,17 @@ table for the disk has been created.
 ## Dev Drive
 
 The Dev Drive feature is currently available on Windows 11 in builds 10.0.22621.2338
-or later. See [the Dev Drive documentation for the latest in formation](https://learn.microsoft.com/en-us/windows/dev-drive/).
+or later. See [the Dev Drive documentation for the latest in formation](https://learn.microsoft.com/windows/dev-drive/).
 
 ### What is a Dev Drive volume and how is it different from regular volumes?
 
 Dev Drive volumes from a storage perspective are just like regular ReFS volumes
-on a Windows machine. The difference However, is that most of the filter drivers
+on a Windows machine. The difference however, is that most of the filter drivers
 except the antivirus filter will not attach to the volume at boot time by default.
 This is a low-level concept that most users will never need to interact with but
-for further reading, see the documentation [here](https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-configure-additional-filters-on-dev-drive)
-for further reading.
+for further reading, see the documentation [here](https://learn.microsoft.com/windows/dev-drive/#how-do-i-configure-additional-filters-on-dev-drive)
+for further reading. In order to create a Dev Drive your configuration must run with
+local administrator permissions or an error will be thrown by the Disk resource.
 
 ### What is the default state of the Dev Drive flag in this resource?
 
@@ -55,17 +56,17 @@ is `50 Gb`.
 
 ### If I have a non Dev Drive volume that is 50 Gb or more can it be reformatted as a Dev Drive volume?
 
-Yes, since the Dev Drive volume is just like any other volume storage wise to the
+Yes, since a Dev Drive volume is just like any other volume storage wise to the
 Windows operating system, a non Dev Drive ReFS volume can be reformatted as a
 Dev Drive volume. An NTFS volume can also be reformatted as a Dev Drive volume.
-Note, the Disk resource will throw an exception, should you also attempt to resize
-a ReFS volume while attempting to reformat it as a Dev Drive volume since ReFS
-volumes cannot be resized. As Dev Drive volumes are also ReFS volumes, they carry
-the same restrictions, see: [Resilient File System (ReFS) overview | Microsoft Learn](https://learn.microsoft.com/en-us/windows-server/storage/refs/refs-overview)
+Note, the Disk resource will throw an exception, should you attempt to resize
+a ReFS volume because ReFS
+volumes cannot be resized. Dev Drive volumes are also ReFS volumes, so they carry
+the same restrictions see: [Resilient File System (ReFS) overview | Microsoft Learn](https://learn.microsoft.com/windows-server/storage/refs/refs-overview)
 
 ### If I don't have any unallocated space available to create a Dev Drive volume, what will happen?
 
-The Disk resource uses the Get-PartitionSupportedSize cmdlet to know which
+The Disk resource uses the `Get-PartitionSupportedSize` cmdlet to know which
 volume can be be resized to a safe size to create enough unallocated space for
 the Dev Drive volume to be created. As long as the size parameter is used, the
 Disk resource will shrink the first non ReFS Drive whose (MaxSize - MinSize) is
@@ -77,7 +78,7 @@ needed, to add to the existing unallocated space so it can be equal to the size
 parameter. For example, if you wanted to create a new 50 Gb Dev Drive volume on
 disk 0, and let's say on disk 0 there was only a 'C' drive that was 800 Gb in size.
 Next to the 'C' drive there was only 40 Gb of free contiguous unallocated space.
-The Disk resource would shrink the 'C' drive by 10 Gb,  creating an addition 10
+The Disk resource would shrink the 'C' drive by 10 Gb,  creating an additional 10
 Gb of unallocated space. Now the unallocated space would be 50 Gb in size. The
 disk resource would then create a new partition and create the Dev Drive volume
 into this new partition.
@@ -98,15 +99,15 @@ There are only five requirements:
    > only prevent new Dev Drive volumes from being created. However, this could
    > affect the `idempotence` for the Drive. For example, changes to this drive
    > after disablement (e.g., reformatting the volume as an NTFS volume) would
-   > not be corrected by rerunning the configuration. Since the feature is
-   > disabled, attempting reformat the volume as a Dev Drive volume will throw an
+   > not be corrected by re-running the configuration. Since the feature is
+   > disabled, attempting to re-format the volume as a Dev Drive volume will throw an
    > error advising you that it is not possible due to the feature being disabled.
 1. If the `size` parameter is entered, the value must be greater than or equal to
    50 Gb in size. We assert that this is true in order to format a Dev Drive
    volume onto a partition.
-1. Currently today, if the `size` parameter is not entered then the Disk resource
+1. If the `size` parameter is not entered then the Disk resource
    will use the maximum space available on the Disk. When the `DevDrive` flag is
-   set to `$true`, then we assert that the maximum available free unallocated space
+   set to `$true`. We assert that the maximum available free unallocated contiguous space
    on the Disk should be `50 Gb or more in size`. This assertion only comes into
    play if the volume doesn't already exist.
 1. The `FSformat` parameter must be set to 'ReFS', when the `DevDrive` flag is

--- a/source/DSCResources/DSC_Disk/en-US/DSC_Disk.strings.psd1
+++ b/source/DSCResources/DSC_Disk/en-US/DSC_Disk.strings.psd1
@@ -52,4 +52,5 @@
     CheckingDevDriveAssertions = Checking system meets requirements for the Dev Drive feature.
     TheVolumeIsNotConfiguredAsADevDriveVolume = The volume with path '{0}' and Drive letter '{1}' is not configured as a Dev Drive volume.
     TheVolumeIsCurrentlyConfiguredAsADevDriveVolume = The volume with path '{0}' and Drive letter '{1}' is currently configured as a Dev Drive volume.
+    DevDriveAdminError = Creating a Dev Drive volume requires running local Administrator permissions. Please ensure this resource is being applied with an account with local Administrator permissions.
 '@

--- a/source/DSCResources/DSC_VirtualHardDisk/DSC_VirtualHardDisk.psm1
+++ b/source/DSCResources/DSC_VirtualHardDisk/DSC_VirtualHardDisk.psm1
@@ -109,16 +109,7 @@ function Set-TargetResource
 
     Assert-ParametersValid -FilePath $FilePath -DiskSize $DiskSize -DiskFormat $DiskFormat
 
-    try
-    {
-        Assert-ElevatedUser
-    }
-    catch
-    {
-        # Use a user friendly error message specific to the virtual disk dsc resource.
-        throw $script:localizedData.VirtualDiskAdminError
-    }
-
+    Assert-ElevatedUserWithCustomErrorMessage -CustomErrorMessage $script:localizedData.VirtualDiskAdminError
     $currentState = Get-TargetResource -FilePath $FilePath
 
     if ($Ensure -eq 'Present')

--- a/source/Modules/StorageDsc.Common/StorageDsc.Common.psm1
+++ b/source/Modules/StorageDsc.Common/StorageDsc.Common.psm1
@@ -628,6 +628,36 @@ function Compare-SizeUsingGB
 
 }# end function Compare-SizeUsingGB
 
+<#
+    .SYNOPSIS
+        Asserts that the configuration is running with local Administrator privileges.
+
+    .PARAMETER CustomErrorMessage
+        A user friendly error message specific to the caller.
+#>
+function Assert-ElevatedUserWithCustomErrorMessage
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $CustomErrorMessage
+    )
+
+    try
+    {
+        Assert-ElevatedUser
+
+    }
+    catch
+    {
+        # Use a user friendly error message specific to the caller
+        throw $CustomErrorMessage
+    }
+
+}# end function Assert-ElevatedUserWithCustomErrorMessage
+
 Export-ModuleMember -Function @(
     'Restart-ServiceIfExists',
     'Assert-DriveLetterValid',
@@ -642,5 +672,6 @@ Export-ModuleMember -Function @(
     'Get-DevDriveEnablementState',
     'Test-DevDriveVolume',
     'Invoke-DeviceIoControlWrapperForDevDriveQuery',
-    'Compare-SizeUsingGB'
+    'Compare-SizeUsingGB',
+    'Assert-ElevatedUserWithCustomErrorMessage'
 )

--- a/tests/Unit/DSC_VirtualHardDisk.Tests.ps1
+++ b/tests/Unit/DSC_VirtualHardDisk.Tests.ps1
@@ -134,6 +134,17 @@ try
             )
         }
 
+        function Assert-ElevatedUserWithCustomErrorMessage
+        {
+            [CmdletBinding()]
+            param
+            (
+                [Parameter(Mandatory = $true)]
+                [System.String]
+                $CustomErrorMessage
+            )
+        }
+
         Describe 'DSC_VirtualHardDisk\Get-TargetResource' {
             Context 'When file path does not exist or was never mounted' {
                 Mock `
@@ -197,7 +208,7 @@ try
         Describe 'DSC_VirtualHardDisk\Set-TargetResource' {
             Context 'When file path is not fully qualified' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $errorRecord = Get-InvalidArgumentRecord `
                     -Message ($script:localizedData.VirtualHardDiskPathError -f `
@@ -217,12 +228,12 @@ try
             }
 
             Context 'When not running as administrator' {
-                Mock `
-                    -CommandName Assert-ElevatedUser `
-                    -MockWith { throw [System.Exception]::new('User not elevated.')} `
-                    -Verifiable
-
                 $exception = [System.Exception]::new($script:localizedData.VirtualDiskAdminError)
+
+                Mock `
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage `
+                    -MockWith { throw [System.Exception]::new($exception.Message)} `
+                    -Verifiable
 
                 It 'Should throw an error message that the user should run resource as admin' {
                     {
@@ -238,7 +249,7 @@ try
 
             Context 'When file extension is not .vhd or .vhdx' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $extension = [System.IO.Path]::GetExtension($DiskImageNonVirtDiskPath).TrimStart('.')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -260,7 +271,7 @@ try
 
             Context 'When file extension does not match the disk format' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $extension = [System.IO.Path]::GetExtension($DiskImageGoodVhdPath).TrimStart('.')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -282,7 +293,7 @@ try
 
             Context 'When file extension is not present in the file path' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $errorRecord = Get-InvalidArgumentRecord `
                     -Message ($script:localizedData.VirtualHardDiskNoExtensionError -f `
@@ -303,7 +314,7 @@ try
 
             Context 'When size provided is less than the minimum size for the vhd format' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $minSizeInMbString = ($DiskImageSizeBelowVirtDiskMinimum / 1MB).ToString('0.00MB')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -325,7 +336,7 @@ try
 
             Context 'When size provided is less than the minimum size for the vhdx format' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $minSizeInMbString = ($DiskImageSizeBelowVirtDiskMinimum / 1MB).ToString('0.00MB')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -347,7 +358,7 @@ try
 
             Context 'When size provided is greater than the maximum size for the vhd format' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $maxSizeInTbString = ($DiskImageSizeAboveVhdMaximum / 1TB).ToString('0.00TB')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -369,7 +380,7 @@ try
 
             Context 'When size provided is greater than the maximum size for the vhdx format' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 $maxSizeInTbString = ($DiskImageSizeAboveVhdxMaximum / 1TB).ToString('0.00TB')
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -391,7 +402,7 @@ try
 
             Context 'When file path to vhdx file is fully qualified' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 It 'Should not throw invalid argument error when path is fully qualified' {
                     {
@@ -407,7 +418,7 @@ try
 
             Context 'When file path to vhd is fully qualified' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 It 'Should not throw invalid argument error when path is fully qualified' {
                     {
@@ -423,7 +434,7 @@ try
 
             Context 'Virtual disk is mounted and ensure set to present' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 Mock `
                     -CommandName Get-DiskImage `
@@ -450,7 +461,7 @@ try
 
             Context 'Virtual disk is mounted and ensure set to absent, so it should be dismounted' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 Mock `
                     -CommandName Get-DiskImage `
@@ -482,7 +493,7 @@ try
 
             Context 'Virtual disk is dismounted and ensure set to present, so it should be re-mounted' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 Mock `
                     -CommandName Get-DiskImage `
@@ -514,7 +525,7 @@ try
 
             Context 'Virtual disk does not exist and ensure set to present, so a new one should be created and mounted' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 Mock `
                     -CommandName Get-DiskImage `
@@ -546,7 +557,7 @@ try
 
             Context 'When folder does not exist in user provided path but an exception occurs after creating the virtual disk' {
                 Mock `
-                    -CommandName Assert-ElevatedUser
+                    -CommandName Assert-ElevatedUserWithCustomErrorMessage
 
                 Mock `
                     -CommandName Get-DiskImage `


### PR DESCRIPTION
#### Pull Request (PR) description

Currently DSC resources can be ran outside of the LCM. For these cases users will need to run their configuration files with Administrator privileges. When users run their Dev Drive specific configurations without running as administrator, the configuration fails due to one of the PowerShell cmdlets failing due to not being ran elevated. This then returns an error to the user that is true for what we were attempting to do but doesn't tell the user that anything failed due to the user not running the configuration as admin. 

To fix this I have added a check for elevation in the Test-TargetResource and the Set-TargetResource methods when the $DevDrive parameter is true. I have also updated the tests for this as well.

I also updated the Disk dsc's readme file with to tell users that running as admin is required. 


#### This Pull Request (PR) fixes the following issues
- Fixes #284


#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/StorageDsc/292)
<!-- Reviewable:end -->
